### PR TITLE
[Version 0.11.2] フィールド追加

### DIFF
--- a/components/organisms/loginForm/index.jsx
+++ b/components/organisms/loginForm/index.jsx
@@ -64,7 +64,7 @@ class LoginForm extends React.Component {
       const imgdata = {
         token: data.data.accessToken,
         user: data.data.userId,
-        expires_in: (time / 1000) + 6 * 60 * 60
+        expires_in: time / 1000 + 6 * 60 * 60
       };
       fetch(IMAGE_SERVER_URI + "/auth.php", {
         method: "POST",

--- a/components/organisms/vaccineForm/index.jsx
+++ b/components/organisms/vaccineForm/index.jsx
@@ -14,7 +14,7 @@ const RecoverInfoForm = props => (
       defaultValue={props.recoverDate}
     />
     <InfoInput
-      title="摂食数"
+      title="いのししの摂食数"
       type="number"
       name="eatenNum"
       min={0}

--- a/components/organisms/vaccineForm/index.jsx
+++ b/components/organisms/vaccineForm/index.jsx
@@ -29,6 +29,14 @@ const RecoverInfoForm = props => (
       step={1}
       defaultValue={props.damageNum}
     />
+    <InfoInput
+      title="破損なし"
+      type="number"
+      name="noDamageNum"
+      min={0}
+      step={1}
+      defaultValue={props.noDamageNum}
+    />
   </div>
 );
 
@@ -68,6 +76,7 @@ class VaccineForm extends React.Component {
                 recoverDate={detail["properties"]["回収年月日"]}
                 eatenNum={detail["properties"]["摂食数"]}
                 damageNum={detail["properties"]["その他の破損数"]}
+                noDamageNum={detail["properties"]["破損なし"]}
               />
             ),
             recover: true
@@ -105,15 +114,14 @@ class VaccineForm extends React.Component {
     // 7 その他の破損数
     let damageNum = "";
     // 8 破損なし
-    // 多分構成ミスなので無し
+    let noDamageNum = "";
     // 9 備考
     const note = form.note.value;
     if (recover) {
       recoverDate = form.recoverDate.value;
-      // eaten = form.eaten.options[form.eaten.selectedIndex].value;
       eatenNum = form.eatenNum.value;
-      // damage = form.damage.options[form.damage.selectedIndex].value;
       damageNum = form.damageNum.value;
+      noDamageNum = form.noDamageNum.value;
     }
 
     // [todo] ここにバリデーション [todo]
@@ -133,6 +141,7 @@ class VaccineForm extends React.Component {
         回収年月日: recoverDate,
         摂食数: eatenNum,
         その他の破損数: damageNum,
+        破損なし: noDamageNum,
         備考: note
       }
     };

--- a/components/organisms/vaccineInfo/index.jsx
+++ b/components/organisms/vaccineInfo/index.jsx
@@ -32,6 +32,11 @@ class VaccineInfo extends React.Component {
           title="その他の破損数"
           type="text"
           data={this.props.detail["properties"]["その他の破損数"]}
+        />,
+        <InfoDiv
+          title="破損なし"
+          type="text"
+          data={this.props.detail["properties"]["破損なし"]}
         />
       ];
     }

--- a/components/organisms/vaccineInfo/index.jsx
+++ b/components/organisms/vaccineInfo/index.jsx
@@ -24,7 +24,7 @@ class VaccineInfo extends React.Component {
           data={this.props.detail["properties"]["回収年月日"]}
         />,
         <InfoDiv
-          title="摂食数"
+          title="いのししの摂食数"
           type="text"
           data={this.props.detail["properties"]["摂食数"]}
         />,

--- a/components/organisms/vaccineInfo/index.jsx
+++ b/components/organisms/vaccineInfo/index.jsx
@@ -29,7 +29,7 @@ class VaccineInfo extends React.Component {
           data={this.props.detail["properties"]["摂食数"]}
         />,
         <InfoDiv
-          title="その他の損傷数"
+          title="その他の破損数"
           type="text"
           data={this.props.detail["properties"]["その他の破損数"]}
         />


### PR DESCRIPTION
#101 関連の修正です
ワクチン情報について，以下のように変更
（すべて「回収済み」の時のみ表示されるものです）

- 「摂食数」→「いのししの摂食数」
    - DBのカラム名の長さ制限により，DB登録時の名称は「摂食数」のまま
    - 見た目表示のみ変更
- （vaccineInfoのみ）「その他の破傷数」→「その他の破損数」
    - タイポしてたので修正
- （新規追加）「破損なし」
