### PR TITLE
[Version 0.13.0] 捕獲情報のフィールド追加 他

### DIFF
--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -43,7 +43,8 @@ class BoarForm extends React.Component {
         date: null,
         meshNo: null,
         length: null
-      }
+      },
+      isFemale: false
     };
     // データが与えられた場合は保存しておく
     if (props.detail != null) {
@@ -89,6 +90,7 @@ class BoarForm extends React.Component {
           });
           break;
       }
+      this.setState({ isFemale: detail["properties"]["性別"] === "メス" });
     }
   }
 
@@ -180,12 +182,17 @@ class BoarForm extends React.Component {
         trapOrEnv = form.trap.options[form.trap.selectedIndex].value;
         break;
     }
-    // 4.1 幼獣・成獣の別
+    // 4-1 幼獣・成獣の別
     const age = form.age.options[form.age.selectedIndex].value;
     // 5 性別
     const sex = form.sex.options[form.sex.selectedIndex].value;
     // 6 体長
     const length = form.length.value;
+    // 6-1 妊娠の状況
+    let pregnant = null;
+    if (this.state.isFemale) {
+      pregnant = form.pregnant.options[form.pregnant.selectedIndex].value;
+    }
     // 7 体重
     const weight = this.weigh(Number(length));
     // 7-1 備考
@@ -210,6 +217,7 @@ class BoarForm extends React.Component {
         性別: sex,
         体長: length,
         体重: weight,
+        妊娠の状況: pregnant,
         備考: note
       }
     };
@@ -229,6 +237,20 @@ class BoarForm extends React.Component {
         this.setState(_ => {
           return { trapOrEnv: TRAP };
         });
+        break;
+    }
+  }
+
+  // 性別が変更されたときに呼ばれる
+  onChangeSex() {
+    const sexSelect = document.forms.form.sex;
+    const sex = sexSelect.options[sexSelect.selectedIndex].value;
+    switch (sex) {
+      case "メス":
+        this.setState({ isFemale: true });
+        break;
+      default:
+        this.setState({ isFemale: false });
         break;
     }
   }
@@ -265,6 +287,7 @@ class BoarForm extends React.Component {
 
   render() {
     if (this.state.lat != undefined && this.state.lng != undefined) {
+      // わな・発見場所の切り替え
       let trapOrEnvSelector = (
         <TrapSelector
           defaultValue={
@@ -280,6 +303,24 @@ class BoarForm extends React.Component {
             defaultValue={
               this.state.detail != null
                 ? this.state.detail["properties"]["罠・発見場所"]
+                : null
+            }
+          />
+        );
+      }
+      // 妊娠の状況の表示切り替え
+      let pregnantSelector = null;
+      if (this.state.isFemale) {
+        pregnantSelector = (
+          <InfoInput
+            title="妊娠の状況"
+            type="select"
+            name="pregnant"
+            options={["なし", "あり", "不明"]}
+            required={true}
+            defaultValue={
+              this.state.detail != null
+                ? this.state.detail["properties"]["妊娠の状況"]
                 : null
             }
           />
@@ -354,6 +395,7 @@ class BoarForm extends React.Component {
                     ? this.state.detail["properties"]["性別"]
                     : "不明"
                 }
+                onChange={this.onChangeSex.bind(this)}
               />
               <InfoInput
                 title="体長 (cm)"
@@ -369,6 +411,7 @@ class BoarForm extends React.Component {
                 onChange={this.validateLength.bind(this)}
                 errorMessage={this.state.error.length}
               />
+              {pregnantSelector}
               <InfoInput
                 title="備考"
                 type="text-area"

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -180,6 +180,8 @@ class BoarForm extends React.Component {
         trapOrEnv = form.trap.options[form.trap.selectedIndex].value;
         break;
     }
+    // 4.1 幼獣・成獣の別
+    const age = form.age.options[form.age.selectedIndex].value;
     // 5 性別
     const sex = form.sex.options[form.sex.selectedIndex].value;
     // 6 体長
@@ -204,6 +206,7 @@ class BoarForm extends React.Component {
         捕獲年月日: date,
         位置情報: "(" + lat + "," + lng + ")",
         "罠・発見場所": trapOrEnv,
+        "幼獣・成獣": age,
         性別: sex,
         体長: length,
         体重: weight,
@@ -330,6 +333,17 @@ class BoarForm extends React.Component {
                 required={true}
               />
               {trapOrEnvSelector}
+              <InfoInput
+                title="幼獣・成獣の別"
+                type="select"
+                name="age"
+                options={["幼獣", "成獣"]}
+                defaultValue={
+                  this.state.detail != null
+                    ? this.state.detail["properties"]["幼獣・成獣"]
+                    : "幼獣"
+                }
+              />
               <InfoInput
                 title="性別"
                 type="select"

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -193,6 +193,8 @@ class BoarForm extends React.Component {
     if (this.state.isFemale) {
       pregnant = form.pregnant.options[form.pregnant.selectedIndex].value;
     }
+    // 6-2 処分方法
+    const disposal = form.disposal.options[form.disposal.selectedIndex].value;
     // 7 体重
     const weight = this.weigh(Number(length));
     // 7-1 備考
@@ -218,6 +220,7 @@ class BoarForm extends React.Component {
         体長: length,
         体重: weight,
         妊娠の状況: pregnant,
+        処分方法: disposal,
         備考: note
       }
     };
@@ -412,6 +415,17 @@ class BoarForm extends React.Component {
                 errorMessage={this.state.error.length}
               />
               {pregnantSelector}
+              <InfoInput
+                title="処分方法"
+                type="select"
+                name="disposal"
+                options={["埋設", "焼却", "家保", "利活用", "その他"]}
+                defaultValue={
+                  this.state.detail != null
+                    ? this.state.detail["properties"]["処分方法"]
+                    : "埋設"
+                }
+              />
               <InfoInput
                 title="備考"
                 type="text-area"

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -42,7 +42,8 @@ class BoarForm extends React.Component {
       error: {
         date: null,
         meshNo: null,
-        length: null
+        length: null,
+        pregnant: null
       },
       isFemale: false
     };
@@ -55,6 +56,7 @@ class BoarForm extends React.Component {
     this.validateMeshNo.bind(this);
     this.validateLength.bind(this);
     this.validateDetail.bind(this);
+    this.validatePregnant.bind(this);
   }
 
   componentDidMount() {
@@ -139,12 +141,39 @@ class BoarForm extends React.Component {
     await this.updateError("length", null);
   }
 
+  async validatePregnant() {
+    if (!this.state.isFemale) {
+      // メスじゃない場合はエラーを消して終了
+      await this.updateError("pregnant", null);
+      return;
+    }
+    // メスの場合
+    const form = document.forms.form;
+    const pregnant = form.pregnant.options[form.pregnant.selectedIndex].value;
+    // 値が選択肢に引っかかればOK
+    const options = ["あり", "なし", "不明"];
+    let valid = false;
+    for (let i = 0; i < options.length; i++) {
+      if (pregnant === options[i]) {
+        valid = true;
+        break;
+      }
+    }
+    if (valid) {
+      await this.updateError("pregnant", null);
+    } else {
+      await this.updateError("pregnant", "選択されていません。");
+    }
+    return;
+  }
+
   // バリデーションをする
   async validateDetail() {
     // 全部チェックしていく
     await this.validateMeshNo();
     await this.validateDate();
     await this.validateLength();
+    await this.validatePregnant();
 
     // エラー一覧を表示
     let valid = true;
@@ -326,6 +355,8 @@ class BoarForm extends React.Component {
                 ? this.state.detail["properties"]["妊娠の状況"]
                 : null
             }
+            errorMessage={this.state.error.pregnant}
+            onChange={this.validatePregnant.bind(this)}
           />
         );
       }

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -458,7 +458,7 @@ class BoarForm extends React.Component {
                 }
               />
               <InfoInput
-                title="備考"
+                title="備考（遠沈管番号）"
                 type="text-area"
                 rows="4"
                 name="note"

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -72,6 +72,11 @@ class BoarInfo extends React.Component {
         />
         {pregnantInfo}
         <InfoDiv
+          title="処分方法"
+          type="text"
+          data={this.props.detail["properties"]["処分方法"]}
+        />
+        <InfoDiv
           title="備考"
           type="longText"
           data={this.props.detail["properties"]["備考"]}

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -39,6 +39,10 @@ class BoarInfo extends React.Component {
           data={this.props.detail["properties"]["罠・発見場所"]}
         />
         <InfoDiv
+          title="幼獣・成獣の別"
+          data={this.props.detail["properties"]["幼獣・成獣"]}
+        />
+        <InfoDiv
           title="性別"
           type="text"
           data={this.props.detail["properties"]["性別"]}

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -4,6 +4,17 @@ import InfoDiv from "../../molecules/infoDiv";
 
 class BoarInfo extends React.Component {
   render() {
+    // 妊娠の状況は性別がメスの時のみ表示
+    let pregnantInfo = null;
+    if (this.props.detail["properties"]["性別"] === "メス") {
+      pregnantInfo = (
+        <InfoDiv
+          title="妊娠の状況"
+          type="text"
+          data={this.props.detail["properties"]["妊娠の状況"]}
+        />
+      );
+    }
     return (
       <div className="boar-info">
         <InfoDiv
@@ -59,6 +70,7 @@ class BoarInfo extends React.Component {
           data={this.props.detail["properties"]["体重"]}
           unit="kg"
         />
+        {pregnantInfo}
         <InfoDiv
           title="備考"
           type="longText"

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -65,7 +65,7 @@ class BoarInfo extends React.Component {
           unit="cm"
         />
         <InfoDiv
-          title="体重 (体長から自動計算)"
+          title="体重 （体長から自動計算）"
           type="number"
           data={this.props.detail["properties"]["体重"]}
           unit="kg"
@@ -77,7 +77,7 @@ class BoarInfo extends React.Component {
           data={this.props.detail["properties"]["処分方法"]}
         />
         <InfoDiv
-          title="備考"
+          title="備考（遠沈管番号）"
           type="longText"
           data={this.props.detail["properties"]["備考"]}
         />

--- a/components/templates/ConfirmEditedInfo/index.jsx
+++ b/components/templates/ConfirmEditedInfo/index.jsx
@@ -20,7 +20,7 @@ class ConfirmEditedInfo extends React.Component {
     this.state = {
       type: null,
       detail: null,
-      ids: null,
+      ids: [],
       formData: null,
       picCount: 0,
       isProcessing: false,
@@ -30,7 +30,7 @@ class ConfirmEditedInfo extends React.Component {
 
   componentDidMount() {
     if (Router.query.type != undefined || Router.query.detail != undefined) {
-      // console.log("confirm", Router.query);
+      // console.log("confirm", JSON.parse(Router.query.ids));
       this.setState({
         type: Router.query.type,
         detail: JSON.parse(Router.query.detail),
@@ -125,7 +125,8 @@ class ConfirmEditedInfo extends React.Component {
         query: {
           id: this.state.detail["properties"]["ID$"],
           type: this.state.type,
-          detail: JSON.stringify(this.state.detail)
+          detail: JSON.stringify(this.state.detail),
+          ids: JSON.stringify(this.state.ids)
         }
       },
       url

--- a/components/templates/EditInfo/index.jsx
+++ b/components/templates/EditInfo/index.jsx
@@ -71,7 +71,7 @@ class EditInfo extends React.Component {
         query: {
           type: this.state.type,
           detail: JSON.stringify(data),
-          ids: this.state.ids,
+          ids: JSON.stringify(this.state.ids),
           formData: JSON.stringify(res)
         }
       },
@@ -88,7 +88,7 @@ class EditInfo extends React.Component {
         id: detail["properties"]["ID$"],
         lat: detail["geometry"]["coordinates"][1],
         lng: detail["geometry"]["coordinates"][0],
-        ids: Router.query.ids
+        ids: JSON.parse(Router.query.ids)
       });
     } else {
       alert("情報の取得に失敗しました。\nもう一度やり直してください。");


### PR DESCRIPTION
#109 の実装に加えて，編集画面でのバグが有ったので修正しました（要確認）

## フィールド追加
- 捕獲情報について，以下のフィールドを追加
    - 幼獣・成獣の別
    - 妊娠の状況
        - 性別がメスの時のみ表示
        - 必須項目・バリデーションも実装（選択式のため，通常の操作ではエラーにならない）
    - 処分方法
- 捕獲情報の「備考」を「備考（遠沈管番号）」に見た目のみ変更


## バグ修正
- 情報編集に関して，「編集画面→確認画面→編集画面→確認画面」と行ったり来たりすると，エラーが発生していた
- 原因は「確認画面→編集画面」と移動する際に画像のidsが渡せていなかったため
- idsを適切に渡せるようにしたはずなので確認お願いします