### PR TITLE
[Version 0.14.0] ユーザーIDの一文字目でユーザー区分を識別する機能＋テスト用vaccineアカウント追加 #113

### DIFF
--- a/utils/userData.js
+++ b/utils/userData.js
@@ -28,6 +28,7 @@ export default class UserData {
           userData.department = "S";
           break;
         case "trap":
+        case "vaccine":
           userData.department = "W";
           break;
         case "pref":
@@ -37,7 +38,7 @@ export default class UserData {
           userData.department = null;
           break;
         default:
-          userData.department = userId.substr(0, 1).toUpperCase();
+          userData.department = userData.user_id.substr(0, 1).toUpperCase();
           break;
       }
       return userData;


### PR DESCRIPTION
- ユーザーIDの1文字目で区分をする機能を実装（バグがあったため修正）
- 新たにvaccineアカウントが追加されたのでその処理を追加（権限はtrapと同じ）