### PR TITLE
[Version 0.14.0] 捕獲情報に捕獲頭数フィールドを追加・他 #114

### DIFF
--- a/components/atomos/infoText/infoText.scss
+++ b/components/atomos/infoText/infoText.scss
@@ -3,4 +3,5 @@
   margin: 10px 0px 10px 0px;
   font-size: 26px;
   color: #212121;
+  white-space: pre-wrap;
 }

--- a/components/atomos/infoText/infoText.scss
+++ b/components/atomos/infoText/infoText.scss
@@ -4,4 +4,5 @@
   font-size: 26px;
   color: #212121;
   white-space: pre-wrap;
+  text-align: justify;
 }

--- a/components/atomos/infoTitle/infoTitle.scss
+++ b/components/atomos/infoTitle/infoTitle.scss
@@ -4,4 +4,5 @@
   font-size: 18px;
   color: #212121;
   font-weight: bold;
+  text-align: justify;
 }

--- a/components/molecules/infoInput/infoInput.scss
+++ b/components/molecules/infoInput/infoInput.scss
@@ -9,6 +9,7 @@
     font-size: 18px;
     color: $text-color;
     font-weight: bold;
+    text-align: justify;
   }
 
   &__error {

--- a/components/organisms/boarForm/boarForm.scss
+++ b/components/organisms/boarForm/boarForm.scss
@@ -1,3 +1,10 @@
+@import "../../../public/static/css/global";
+
 .boar-form {
   width: 100%;
+
+  &__description {
+    margin: 15px $margin-lr $margin-tb $margin-lr;
+    text-align: justify;
+  }
 }

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -10,26 +10,6 @@ import "../../../utils/dict";
 const TRAP = 1;
 const ENV = 2;
 
-const TrapSelector = props => (
-  <InfoInput
-    title="わなの種類"
-    type="select"
-    name="trap"
-    options={["箱わな", "くくりわな", "その他"]}
-    defaultValue={props.defaultValue}
-  />
-);
-
-const EnvSelector = props => (
-  <InfoInput
-    title="発見場所"
-    type="select"
-    name="env"
-    options={["山際", "山地", "その他"]}
-    defaultValue={props.defaultValue}
-  />
-);
-
 class BoarForm extends React.Component {
   constructor(props) {
     super(props);
@@ -321,17 +301,25 @@ class BoarForm extends React.Component {
     if (this.state.lat != undefined && this.state.lng != undefined) {
       // わな・発見場所の切り替え
       let trapOrEnvSelector = (
-        <TrapSelector
+        <InfoInput
+          title="わなの種類"
+          type="select"
+          name="trap"
+          options={["くくりわな", "箱わな", "その他"]}
           defaultValue={
             this.state.detail != null
               ? this.state.detail["properties"]["罠・発見場所"]
-              : null
+              : "くくりわな"
           }
         />
       );
       if (this.state.trapOrEnv === ENV) {
         trapOrEnvSelector = (
-          <EnvSelector
+          <InfoInput
+            title="発見場所"
+            type="select"
+            name="env"
+            options={["山際", "山地", "その他"]}
             defaultValue={
               this.state.detail != null
                 ? this.state.detail["properties"]["罠・発見場所"]

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -24,10 +24,10 @@ class BoarForm extends React.Component {
         meshNo: null,
         length: null,
         pregnant: null,
-        catchNum: null,
+        catchNum: null
       },
       isFemale: false,
-      isBox: false,
+      isBox: false
     };
     // データが与えられた場合は保存しておく
     if (props.detail != null) {
@@ -76,7 +76,9 @@ class BoarForm extends React.Component {
           break;
       }
       this.setState({ isFemale: detail["properties"]["性別"] === "メス" });
-      this.setState({ isBox: detail["properties"]["罠・発見場所"] === "箱わな"});
+      this.setState({
+        isBox: detail["properties"]["罠・発見場所"] === "箱わな"
+      });
     }
   }
 
@@ -152,7 +154,7 @@ class BoarForm extends React.Component {
   }
 
   async validateCatchNum() {
-    if (this.state.isBox) {
+    if (!this.state.isBox) {
       // 箱わなが選択されていない場合はnull
       await this.updateError("catchNum", null);
       return;
@@ -371,7 +373,7 @@ class BoarForm extends React.Component {
             defaultValue={
               this.state.detail != null
                 ? this.state.detail["properties"]["罠・発見場所"]
-                : null
+                : "山際"
             }
           />
         );
@@ -398,8 +400,8 @@ class BoarForm extends React.Component {
       }
       // 捕獲頭数の表示切り替え
       let catchNumInput = null;
-      if(this.state.isBox) {
-        catchNumInput = (
+      if (this.state.isBox) {
+        catchNumInput = [
           <InfoInput
             title="捕獲頭数"
             type="number"
@@ -413,8 +415,11 @@ class BoarForm extends React.Component {
             }
             onChange={this.validateCatchNum.bind(this)}
             errorMessage={this.state.error.catchNum}
-            />
-        );
+          />,
+          <p className="boar-form__description">
+            以下の項目については、代表的な1体のみに関して入力してください。
+          </p>
+        ];
       }
       return (
         <div className="boar-form">

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -417,7 +417,7 @@ class BoarForm extends React.Component {
             errorMessage={this.state.error.catchNum}
           />,
           <p className="boar-form__description">
-            以下の項目については、代表的な1体のみに関して入力してください。
+            ※以下の項目については、代表的なイノシシ1体の情報を入力してください。
           </p>
         ];
       }
@@ -520,7 +520,7 @@ class BoarForm extends React.Component {
                 }
               />
               <InfoInput
-                title="備考（遠沈管番号）"
+                title="備考（捕獲を手伝った者の氏名）（遠沈管番号）"
                 type="text-area"
                 rows="4"
                 name="note"

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -89,7 +89,7 @@ class BoarInfo extends React.Component {
           data={this.props.detail["properties"]["処分方法"]}
         />
         <InfoDiv
-          title="備考（遠沈管番号）"
+          title="備考（捕獲を手伝った者の氏名）（遠沈管番号）"
           type="longText"
           data={this.props.detail["properties"]["備考"]}
         />

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -23,7 +23,7 @@ class BoarInfo extends React.Component {
           title="捕獲頭数"
           type="text"
           data={this.props.detail["properties"]["捕獲頭数"]}
-          />
+        />
       );
     }
     return (

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -15,6 +15,17 @@ class BoarInfo extends React.Component {
         />
       );
     }
+    // 捕獲頭数は箱わなが選択された時のみ表示
+    let catchNumInfo = null;
+    if (this.props.detail["properties"]["罠・発見場所"] === "箱わな") {
+      catchNumInfo = (
+        <InfoDiv
+          title="捕獲頭数"
+          type="text"
+          data={this.props.detail["properties"]["捕獲頭数"]}
+          />
+      );
+    }
     return (
       <div className="boar-info">
         <InfoDiv
@@ -49,6 +60,7 @@ class BoarInfo extends React.Component {
           title="わな・発見場所"
           data={this.props.detail["properties"]["罠・発見場所"]}
         />
+        {catchNumInfo}
         <InfoDiv
           title="幼獣・成獣の別"
           data={this.props.detail["properties"]["幼獣・成獣"]}

--- a/components/organisms/mapForAddInfo/mapForAddInfo.scss
+++ b/components/organisms/mapForAddInfo/mapForAddInfo.scss
@@ -13,6 +13,7 @@
   .description {
     margin: 15px var(--margin-lr) var(--margin-tb) var(--margin-lr);
     height: auto;
+    text-align: justify;
   }
 
   .mapForAddInfoDiv {

--- a/components/organisms/trapForm/index.jsx
+++ b/components/organisms/trapForm/index.jsx
@@ -233,11 +233,11 @@ class TrapForm extends React.Component {
                 title="わなの種類"
                 type="select"
                 name="kind"
-                options={["箱わな", "くくりわな", "その他"]}
+                options={["くくりわな", "箱わな", "その他"]}
                 defaultValue={
                   this.state.detail != null
                     ? this.state.detail["properties"]["罠の種類"]
-                    : null
+                    : "くくりわな"
                 }
               />
               <InfoInput

--- a/components/templates/AddInfo/addInfo.scss
+++ b/components/templates/AddInfo/addInfo.scss
@@ -20,6 +20,7 @@ body {
 
   .description {
     margin: 15px var(--margin-lr) var(--margin-tb) var(--margin-lr);
+    text-align: justify;
   }
 }
 


### PR DESCRIPTION
#114 の修正です

## 捕獲頭数フィールドを追加
- 捕獲情報の「わなの種類」（※「区分」を「調査捕獲」or「有害捕獲」にした時のみ表示）として「箱わな」を設定すると，「捕獲頭数」フィールドが表示される
- 「捕獲頭数」は数値フィールドで必須項目，1以上の値を入力する必要がある
- これに伴い，これ以降の項目が代表1体のみのデータを入力することになるので注意書きも表示

## その他修正
- 「備考（遠沈管番号）」→「備考（捕獲を手伝った者の氏名）（遠沈管番号）」に変更
- 一部長文のテキストに「text-align: justify;」を追加
- 備考欄の改行に対応