### PR TITLE
[Version 0.15.1]（捕獲を手伝った者の氏名）を削除 #137

### DIFF
--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -611,7 +611,7 @@ class BoarForm extends React.Component {
                 }
               />
               <InfoInput
-                title="備考（捕獲を手伝った者の氏名）（遠沈管番号）"
+                title="備考（遠沈管番号）"
                 type="text-area"
                 rows="4"
                 name="note"

--- a/components/organisms/boarInfo/index.jsx
+++ b/components/organisms/boarInfo/index.jsx
@@ -94,7 +94,7 @@ class BoarInfo extends React.Component {
           data={this.props.detail["properties"]["処分方法"]}
         />
         <InfoDiv
-          title="備考（捕獲を手伝った者の氏名）（遠沈管番号）"
+          title="備考（遠沈管番号）"
           type="longText"
           data={this.props.detail["properties"]["備考"]}
         />


### PR DESCRIPTION
- version 0.14.0で「備考（遠沈管番号）」を「備考（捕獲を手伝った者の氏名）（遠沈管番号）」に修正したのをもとに戻しただけです．

- 2箇所のテキストが差し替わっただけなのでこのままマージしちゃいます