### PR TITLE
[Version0.16.1] マップ周りの修正 #148+#149+#150+α

### DIFF
--- a/components/atomos/miniMapDiv/index.jsx
+++ b/components/atomos/miniMapDiv/index.jsx
@@ -34,6 +34,10 @@ class MiniMapDiv extends React.Component {
     this.map();
   }
 
+  componentWillUnmount() {
+    this.state.myMap.remove();
+  }
+
   map() {
     const node = this.node;
     this.state.myMap = L.map(node, { keyboard: false }).setView(

--- a/components/atomos/miniMapDiv/index.jsx
+++ b/components/atomos/miniMapDiv/index.jsx
@@ -6,8 +6,6 @@ import EventListener from "react-event-listener";
 import UserData from "../../../utils/userData";
 
 class MiniMapDiv extends React.Component {
-  myMap = null;
-
   constructor(props) {
     super(props);
 
@@ -25,10 +23,10 @@ class MiniMapDiv extends React.Component {
     }
 
     this.state = {
+      myMap: null,
       lat: this.props.lat,
       lng: this.props.lng,
-      zoom: defaultZoom,
-      myMap: null
+      zoom: defaultZoom
     };
   }
 
@@ -38,7 +36,7 @@ class MiniMapDiv extends React.Component {
 
   map() {
     const node = this.node;
-    this.myMap = L.map(node).setView(
+    this.state.myMap = L.map(node, { keyboard: false }).setView(
       [this.state.lat, this.state.lng],
       this.state.zoom
     );
@@ -63,9 +61,9 @@ class MiniMapDiv extends React.Component {
           value: userData.access_token
         }
       ]
-    ).addTo(this.myMap);
+    ).addTo(this.state.myMap);
 
-    L.control.scale().addTo(this.myMap);
+    L.control.scale().addTo(this.state.myMap);
 
     // 十字
     const centerCrossIcon = L.icon({
@@ -77,7 +75,7 @@ class MiniMapDiv extends React.Component {
     const centerCross = L.marker([this.state.lat, this.state.lng], {
       icon: centerCrossIcon,
       zIndexOffset: 400
-    }).addTo(this.myMap);
+    }).addTo(this.state.myMap);
     // ピン
     const centerPinIcon = L.icon({
       iconUrl: "../../../static/images/map/centerPin.svg",
@@ -88,13 +86,13 @@ class MiniMapDiv extends React.Component {
     const centerPin = L.marker([this.state.lat, this.state.lng], {
       icon: centerPinIcon,
       zIndexOffset: 400
-    }).addTo(this.myMap);
+    }).addTo(this.state.myMap);
   }
 
   // 画面リサイズで呼ばれる
   handleResize = () => {
     setTimeout(() => {
-      this.myMap.invalidateSize();
+      this.state.myMap.invalidateSize();
     }, 200);
   };
 

--- a/components/organisms/mapBase/index.jsx
+++ b/components/organisms/mapBase/index.jsx
@@ -37,7 +37,6 @@ class MapBase extends React.Component {
   });
 
   myLocIcon = "static/images/map/location_marker.svg";
-  myMap = null;
 
   constructor(props) {
     super(props);
@@ -108,6 +107,7 @@ class MapBase extends React.Component {
 
     // state初期化
     this.state = {
+      myMap: null,
       lat: defaultLat,
       lng: defautlLng,
       zoom: defaultZoom,
@@ -161,14 +161,14 @@ class MapBase extends React.Component {
 
   map() {
     const node = this.node;
-    this.myMap = L.map(node).setView(
+    this.state.myMap = L.map(node, { keyboard: false }).setView(
       [this.state.lat, this.state.lng],
       this.state.zoom
     );
 
     if (this.state.isDefault) {
       // 県庁の場合位置情報を取得する。
-      this.getCurrentLocation(this.myMap);
+      this.getCurrentLocation(this.state.myMap);
     }
 
     const userData = this.state.userData;
@@ -194,32 +194,32 @@ class MapBase extends React.Component {
           value: userData.access_token
         }
       ]
-    ).addTo(this.myMap);
+    ).addTo(this.state.myMap);
 
-    this.updateMarkers(this.myMap, userData.access_token);
+    this.updateMarkers(this.state.myMap, userData.access_token);
 
     const me = this;
 
-    this.myMap.on("moveend", function(e) {
+    this.state.myMap.on("moveend", function(e) {
       console.log("map-moveend");
-      me.saveMapState(me.myMap);
-      me.updateMarkers(me.myMap, userData.access_token);
+      me.saveMapState(me.state.myMap);
+      me.updateMarkers(me.state.myMap, userData.access_token);
     });
 
-    this.myMap.on("zoomend", function(e) {
+    this.state.myMap.on("zoomend", function(e) {
       console.log("map-zoomend");
-      me.saveMapState(me.myMap);
-      me.updateMarkers(me.myMap, userData.access_token);
+      me.saveMapState(me.state.myMap);
+      me.updateMarkers(me.state.myMap, userData.access_token);
     });
 
-    this.myMap.on("resize", function(e) {
+    this.state.myMap.on("resize", function(e) {
       console.log("map-resize");
-      me.saveMapState(me.myMap);
-      me.updateMarkers(me.myMap, userData.access_token);
+      me.saveMapState(me.state.myMap);
+      me.updateMarkers(me.state.myMap, userData.access_token);
     });
 
     // 拡大縮小ボタン追加
-    L.control.scale().addTo(this.myMap);
+    L.control.scale().addTo(this.state.myMap);
 
     // 現在地取得ボタンを作成＋追加
     L.easyButton({
@@ -236,20 +236,20 @@ class MapBase extends React.Component {
           icon: "fa-location-arrow"
         }
       ]
-    }).addTo(this.myMap);
+    }).addTo(this.state.myMap);
 
     // 各種レイヤー追加
-    Object.values(this.state.overlays).forEach(o => o.addTo(this.myMap));
+    Object.values(this.state.overlays).forEach(o => o.addTo(this.state.myMap));
     // コントロール追加
     this.state.control = L.control.layers(undefined, this.state.overlays, {
       collapsed: false
     });
     // チェックボックスを配置
-    this.state.control.addTo(this.myMap);
+    this.state.control.addTo(this.state.myMap);
 
     // 再読み込みボタンを再配置
     this.state.reloadButton.remove();
-    this.state.reloadButton.addTo(this.myMap);
+    this.state.reloadButton.addTo(this.state.myMap);
   }
 
   async updateMarkers(map) {
@@ -257,8 +257,6 @@ class MapBase extends React.Component {
     const userDepartment = this.state.userData.department;
     // 表示範囲を取得
     const bounds = map.getBounds();
-
-    const newLayers = {};
 
     // 各フィーチャーを取得
     try {
@@ -500,7 +498,7 @@ class MapBase extends React.Component {
         document.getElementById("map").style.height = mapHeight + "px";
         // マップのサイズを確認して修正する
         console.log("handleResize");
-        this.myMap.invalidateSize();
+        this.state.myMap.invalidateSize();
       }.bind(this),
       200
     );

--- a/components/organisms/mapBase/index.jsx
+++ b/components/organisms/mapBase/index.jsx
@@ -10,7 +10,6 @@ import "../../../utils/statics";
 import EventListener from "react-event-listener";
 import UserData from "../../../utils/userData";
 import "leaflet.markercluster";
-import { type } from "os";
 
 // 現在地マーカー
 let locMarker = undefined;

--- a/components/organisms/mapBase/index.jsx
+++ b/components/organisms/mapBase/index.jsx
@@ -164,6 +164,8 @@ class MapBase extends React.Component {
     console.log("unmount");
     // アンマウント時に位置情報の取得をストップ
     this.stopWatchLocation();
+    // マップを破棄
+    this.state.myMap.remove();
   }
 
   map() {

--- a/components/organisms/mapBase/index.jsx
+++ b/components/organisms/mapBase/index.jsx
@@ -8,6 +8,7 @@ import "leaflet-easybutton";
 import "../../../utils/statics";
 import EventListener from "react-event-listener";
 import UserData from "../../../utils/userData";
+import "leaflet.markercluster";
 
 // 現在地マーカー
 let locMarker = undefined;

--- a/components/organisms/mapBase/leafletCluster.scss
+++ b/components/organisms/mapBase/leafletCluster.scss
@@ -1,0 +1,76 @@
+.marker-cluster-small {
+	background-color: rgba(181, 226, 140, 0.6);
+	}
+.marker-cluster-small div {
+	background-color: rgba(110, 204, 57, 0.6);
+	}
+
+.marker-cluster-medium {
+	background-color: rgba(241, 211, 87, 0.6);
+	}
+.marker-cluster-medium div {
+	background-color: rgba(240, 194, 12, 0.6);
+	}
+
+.marker-cluster-large {
+	background-color: rgba(253, 156, 115, 0.6);
+	}
+.marker-cluster-large div {
+	background-color: rgba(241, 128, 23, 0.6);
+	}
+
+	/* IE 6-8 fallback colors */
+.leaflet-oldie .marker-cluster-small {
+	background-color: rgb(181, 226, 140);
+	}
+.leaflet-oldie .marker-cluster-small div {
+	background-color: rgb(110, 204, 57);
+	}
+
+.leaflet-oldie .marker-cluster-medium {
+	background-color: rgb(241, 211, 87);
+	}
+.leaflet-oldie .marker-cluster-medium div {
+	background-color: rgb(240, 194, 12);
+	}
+
+.leaflet-oldie .marker-cluster-large {
+	background-color: rgb(253, 156, 115);
+	}
+.leaflet-oldie .marker-cluster-large div {
+	background-color: rgb(241, 128, 23);
+}
+
+.marker-cluster {
+	background-clip: padding-box;
+	border-radius: 20px;
+	}
+.marker-cluster div {
+	width: 30px;
+	height: 30px;
+	margin-left: 5px;
+	margin-top: 5px;
+
+	text-align: center;
+	border-radius: 15px;
+	font: 12px "Helvetica Neue", Arial, Helvetica, sans-serif;
+	}
+.marker-cluster span {
+	line-height: 30px;
+  }
+
+
+.leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow {
+	-webkit-transition: -webkit-transform 0.3s ease-out, opacity 0.3s ease-in;
+	-moz-transition: -moz-transform 0.3s ease-out, opacity 0.3s ease-in;
+	-o-transition: -o-transform 0.3s ease-out, opacity 0.3s ease-in;
+	transition: transform 0.3s ease-out, opacity 0.3s ease-in;
+}
+
+.leaflet-cluster-spider-leg {
+	/* stroke-dashoffset (duration and function) should match with leaflet-marker-icon transform in order to track it exactly */
+	-webkit-transition: -webkit-stroke-dashoffset 0.3s ease-out, -webkit-stroke-opacity 0.3s ease-in;
+	-moz-transition: -moz-stroke-dashoffset 0.3s ease-out, -moz-stroke-opacity 0.3s ease-in;
+	-o-transition: -o-stroke-dashoffset 0.3s ease-out, -o-stroke-opacity 0.3s ease-in;
+	transition: stroke-dashoffset 0.3s ease-out, stroke-opacity 0.3s ease-in;
+}

--- a/components/organisms/mapBase/mapBase.scss
+++ b/components/organisms/mapBase/mapBase.scss
@@ -14,6 +14,28 @@
   }
 }
 
+// marker-cluster
+.marker-cluster-vaccine {
+	background-color: rgba(140, 180, 226, 0.6);
+	}
+.marker-cluster-vaccine div {
+	background-color: rgba(57, 157, 204, 0.6);
+	}
+
+.marker-cluster-trap {
+	background-color: rgba(241, 211, 87, 0.6);
+	}
+.marker-cluster-trap div {
+	background-color: rgba(240, 194, 12, 0.6);
+	}
+
+.marker-cluster-boar {
+	background-color: rgba(253, 156, 115, 0.6);
+	}
+.marker-cluster-boar div {
+	background-color: rgba(241, 128, 23, 0.6);
+	}
+
 #map {
   position: absolute;
   width: 100%;

--- a/components/organisms/mapForAddInfo/index.jsx
+++ b/components/organisms/mapForAddInfo/index.jsx
@@ -43,7 +43,7 @@ class MapForAddInfo extends MapBase {
   map() {
     super.map();
     // 下のon関数の中ではthisが使えないのでコピー
-    const mapObj = this.myMap;
+    const mapObj = this.state.myMap;
     // 十字
     const centerCrossIcon = L.icon({
       iconUrl: "../../static/images/map/centerCross.svg",
@@ -96,7 +96,7 @@ class MapForAddInfo extends MapBase {
     setTimeout(
       function() {
         console.log("tests");
-        this.myMap.invalidateSize();
+        this.state.myMap.invalidateSize();
       }.bind(this),
       200
     );

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "isomorphic-fetch": "^2.2.1",
     "leaflet": "^1.6.0",
     "leaflet-easybutton": "^2.4.0",
+    "leaflet.markercluster": "^1.4.1",
     "next": "^9.3.2",
     "next-cookies": "^2.0.3",
     "react": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,6 +4623,11 @@ leaflet-easybutton@^2.4.0:
   dependencies:
     leaflet "^1.0.1"
 
+leaflet.markercluster@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/leaflet.markercluster/-/leaflet.markercluster-1.4.1.tgz#b53f2c4f2ca7306ddab1dbb6f1861d5e8aa6c5e5"
+  integrity sha512-ZSEpE/EFApR0bJ1w/dUGwTSUvWlpalKqIzkaYdYB7jaftQA/Y2Jav+eT4CMtEYFj+ZK4mswP13Q2acnPBnhGOw==
+
 leaflet@^1.0.1, leaflet@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.6.0.tgz#aecbb044b949ec29469eeb31c77a88e2f448f308"


### PR DESCRIPTION
マップ周りの色々修正

- [ ] #148 位置情報取得方法を単発取得→追跡に変更
    - [ ] バックグラウンドで位置情報を更新し続けることで，画面遷移した後も自己位置にマーカーが置かれるように修正
- [ ] #149 フィーチャの描画方法を，一度描画したフィーチャーを削除しないように変更
- [ ] #150 markerClusterを導入，近隣のマーカを集めるように実装
- [ ] 他の画面に遷移したときにleafletに操作をもっていかれるバグを修正
    - [ ] keyboardによる操作を禁止
    - [ ] マップが画面から消えるときにマップを破棄するように変更