### PR TITLE
Feature/version0.16.2

### DIFF
--- a/components/atomos/meshNoInput/index.jsx
+++ b/components/atomos/meshNoInput/index.jsx
@@ -171,7 +171,7 @@ class MeshNoInput extends React.Component {
     const numValueRow = document.getElementById(this.props.id + "Num").value;
     // 有効な桁数の時のみセット
     const numRegExp = new RegExp(
-      /(^\d{1,4}-\d{0,2}$)|(^\d{1,4}$)|(^[A-Fa-f]\d{4}$)/,
+      /(^\d{1,4}-\d{0,2}$)|(^\d{1,4}$)|(^[A-Fa-f]\d{1,4}$)/,
       "g"
     );
     const result = numRegExp.exec(numValueRow);
@@ -179,7 +179,7 @@ class MeshNoInput extends React.Component {
       // 三項演算子が見づらいですが，
       // result[1]でマッチ → (^\d{1,4}-\d{0,2}$) ＝ 頭0埋めをして4桁-2桁にする
       // result[2]でマッチ → (^\d{1,4}$) ＝ 頭を0埋めし，省略されたハイフンと下二桁(00)を補完
-      // result[3]でマッチ → (^[A-Fa-f]\d{4}$) = 市町村が使うメッシュ番号，大文字に統一
+      // result[3]でマッチ → (^[A-Fa-f]\d{1,4}$) = 市町村が使うメッシュ番号，大文字に統一，0埋めして4桁
       const numValue = result[1]
         ? ("0000" + result[1].split("-")[0]).slice(-4) +
           "-" +
@@ -187,7 +187,8 @@ class MeshNoInput extends React.Component {
         : result[2]
         ? ("0000" + result[2]).slice(-4) + "-00"
         : result[3]
-        ? result[3].toUpperCase()
+        ? result[3].slice(0, 1).toUpperCase() +
+          ("0000" + result[3].slice(1)).slice(-4)
         : null;
       console.log(numValue);
       this.setValue(cityValue, numValue);

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -285,6 +285,11 @@ class BoarForm extends React.Component {
     }
     // 4-1 幼獣・成獣の別
     const age = form.age.options[form.age.selectedIndex].value;
+    if (!this.state.isBox) {
+      catchNum = 1;
+      childrenNum = age === "幼獣" ? 1 : 0;
+      adultsNum = age === "成獣" ? 1 : 0;
+    }
     // 5 性別
     const sex = form.sex.options[form.sex.selectedIndex].value;
     // 6 体長

--- a/components/templates/ConfirmEditedInfo/index.jsx
+++ b/components/templates/ConfirmEditedInfo/index.jsx
@@ -141,6 +141,7 @@ class ConfirmEditedInfo extends React.Component {
       // 1枚も画像がなければ空の配列を返す
       if (this.state.imageBlobs.length === 0) {
         resolve([]);
+        return;
       }
       // 1枚以上画像があれば，アップロード→idを返す
       const ids = [];
@@ -182,6 +183,39 @@ class ConfirmEditedInfo extends React.Component {
   deleteImages() {
     // TODO
     console.log("削除画像", this.state.deletedIDs);
+    // 一枚ずつ消す
+    const deleteImage = id => {
+      return new Promise(async (resolve, reject) => {
+        try {
+          const data = new FormData();
+          data.append("id", id);
+          const options = {
+            credentials: "include",
+            method: "POST",
+            body: data,
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/x-www-form-urlencoded"
+            }
+          };
+          delete options.headers["Content-Type"];
+          const res = await fetch(
+            `${SERVER_URI}/Image/DeleteImage.php`,
+            options
+          );
+          const json = await res.json();
+          console.log("deleteImage", json);
+          if (res.status === 200) {
+            resolve();
+          } else {
+            reject(json["reason"]);
+          }
+        } catch (e) {
+          reject(e);
+        }
+      });
+    };
+    return Promise.all(this.state.deletedIDs.map(id => deleteImage(id)));
   }
 
   // GISにpostする

--- a/components/templates/Detail/index.jsx
+++ b/components/templates/Detail/index.jsx
@@ -116,12 +116,50 @@ class Detail extends React.Component {
       // id取得
       const id = this.state.detail["properties"]["ID$"];
       const layerId = BOAR_LAYER_ID + parseInt(Router.query.type);
+      // 画像を消す
+      const deleteImageIds = this.state.detail["properties"]["画像ID"].split(
+        ","
+      );
+      const deleteImage = id => {
+        console.log(id);
+        return new Promise(async (resolve, reject) => {
+          try {
+            const data = new FormData();
+            data.append("id", id);
+            const options = {
+              credentials: "include",
+              method: "POST",
+              body: data,
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/x-www-form-urlencoded"
+              }
+            };
+            delete options.headers["Content-Type"];
+            const res = await fetch(
+              `${SERVER_URI}/Image/DeleteImage.php`,
+              options
+            );
+            const json = await res.json();
+            console.log("deleteImage", json);
+            if (res.status === 200) {
+              resolve();
+            } else {
+              reject(json["reason"]);
+            }
+          } catch (e) {
+            reject(e);
+          }
+        });
+      };
       // GISにフェッチ
       const body = {
         layerId: layerId,
         shapeIds: [id]
       };
       try {
+        // 先に画像を消す
+        Promise.all(deleteImageIds.map(id => deleteImage(id)));
         const res = await fetch(SERVER_URI + "/Feature/DeleteFeatures.php", {
           method: "POST",
           headers: {


### PR DESCRIPTION
細かいの３つ追加で直しました（増やしてごめん）

- #162 「箱わな」以外を選択した場合、幼獣・成獣に合わせて捕獲頭数を設定
- #163 フロント側から画像削除のapiを叩くように実装
- #164 メッシュ番号の「アルファベット＋1~3桁」に対応

```
[meta]
[version]Version 0.16.2[/version]
[contents]
捕獲情報の登録時に「箱わな」以外の罠を設定した場合に、捕獲頭数が設定されない不具合を修正しました。
メッシュ番号入力時、「アルファベット＋1~3桁」にも対応しました。
[/contents]
[/meta]
```