### PR TITLE
[Version 1.2.0?]`confirm`と`alert`の自作コンポーネント化

### DIFF
--- a/components/atomos/imagesInput/index.jsx
+++ b/components/atomos/imagesInput/index.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import RoundButton from "../roundButton";
 
 import { SERVER_URI } from "../../../utils/gis";
+import { alert } from "../../../utils/modals";
 
 class ImagesInput extends React.Component {
   constructor(props) {
@@ -102,7 +103,7 @@ class ImagesInput extends React.Component {
         input.files.length >
       10
     ) {
-      alert("一度に登録できる画像は10枚までです");
+      await alert("一度に登録できる画像は10枚までです");
       return;
     }
     // 入力された各画像に関して

--- a/components/atomos/imagesInput/index.jsx
+++ b/components/atomos/imagesInput/index.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import RoundButton from "../roundButton";
 
 import { SERVER_URI } from "../../../utils/gis";
-import { alert } from "../../../utils/modals";
+import { alert, confirm } from "../../../utils/modals";
 
 class ImagesInput extends React.Component {
   constructor(props) {
@@ -128,8 +128,8 @@ class ImagesInput extends React.Component {
   }
 
   // 各画像の上のバツボタンを押したときの処理
-  onClickEreseButton(index) {
-    if (confirm("この画像の登録を取り消しますか？")) {
+  async onClickEreseButton(index) {
+    if (await confirm("この画像の登録を取り消しますか？")) {
       console.log(index);
       console.log(this.state.objectURLs[index]);
       // 押された番号のobjectURLを消す
@@ -148,8 +148,8 @@ class ImagesInput extends React.Component {
   }
 
   // もともと登録されている画像のバツボタン
-  onClickEreseButtonForServerImage(index) {
-    if (confirm("この画像の登録を取り消しますか？")) {
+  async onClickEreseButtonForServerImage(index) {
+    if (await confirm("この画像の登録を取り消しますか？")) {
       console.log(index);
       console.log(this.state.imageIDs[index]);
       // 押された番号のimageIDを消す

--- a/components/atomos/modalBg/index.tsx
+++ b/components/atomos/modalBg/index.tsx
@@ -1,0 +1,17 @@
+// モーダルの背景
+// 入力を防ぐ
+
+import React from 'react';
+import "./modalBg.scss";
+
+class ModalBg extends React.Component {
+  render() {
+    return (
+      <div className="modal-bg">
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+export default ModalBg;

--- a/components/atomos/modalBg/modalBg.scss
+++ b/components/atomos/modalBg/modalBg.scss
@@ -1,0 +1,23 @@
+@import "../../../public/static/css/global";
+
+.modal-bg {
+  // 画面全面に広げる
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+
+  // どの要素より前に出すため，大きめの値を設定
+  z-index: 100;
+
+  // 背景色とブラー
+  background-color: rgba($color: $text-color, $alpha: 0.3);
+  backdrop-filter: blur(10px);
+
+  // 子要素を上下中央揃え
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/components/atomos/modalWindow/index.tsx
+++ b/components/atomos/modalWindow/index.tsx
@@ -1,0 +1,26 @@
+// モーダルのウィンドウ
+
+import React from 'react';
+import "./modalWindow.scss";
+
+type Props = {
+
+};
+
+type State = {
+
+};
+
+class ModalWindow extends React.Component<Props, State> {
+  render() {
+    return (
+      <div className="modal-window">
+        {
+          this.props.children
+        }
+      </div>
+    )
+  }
+}
+
+export default ModalWindow;

--- a/components/atomos/modalWindow/modalWindow.scss
+++ b/components/atomos/modalWindow/modalWindow.scss
@@ -1,0 +1,13 @@
+@import "../../../public/static/css/global";
+
+.modal-window {
+  width: 90%;
+  max-width: 360px;
+  height: auto;
+  box-sizing: border-box;
+
+  padding: 15px 15px;
+
+  background-color: $background-color;
+  filter: drop-shadow(0 0 10px $text-color);
+}

--- a/components/molecules/alertModal/alertModal.scss
+++ b/components/molecules/alertModal/alertModal.scss
@@ -1,0 +1,20 @@
+@import "../../../public/static/css/global";
+
+.modal-body {
+  white-space: pre-wrap;
+}
+
+.modal-footer {
+  margin-top: 15px;
+
+  display: flex;
+  justify-content: space-around;
+
+  .button-wrapper {
+    width: 40%;
+  }
+
+  .button-text {
+    font-size: 16px;
+  }
+}

--- a/components/molecules/alertModal/index.tsx
+++ b/components/molecules/alertModal/index.tsx
@@ -1,0 +1,69 @@
+// 選択肢がOKしか無いアラートのモーダル
+
+import React from 'react';
+import ModalBg from '../../atomos/modalBg';
+import ModalWindw from '../../atomos/modalWindow';
+import RoundButton from '../../atomos/roundButton';
+
+import "./alertModal.scss";
+
+type Props = {
+  message: string;
+  resolve: (res: Boolean) => void;
+  cleanup: () => void;
+};
+
+type State = {
+  show: boolean;
+};
+
+class AlertModal extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: true
+    };
+  }
+
+  onClickCancel() {
+    const { resolve, cleanup } = this.props;
+    this.setState({ show: false }, () => {
+      resolve(false);
+      cleanup();
+    });
+  };
+
+  onClickOk() {
+    const { resolve, cleanup } = this.props;
+    this.setState({ show: false }, () => {
+      resolve(true);
+      cleanup();
+    });
+  };
+
+  render() {
+    const { show } = this.state;
+
+    return (
+      <ModalBg>
+        <ModalWindw>
+          <div className="modal-body">
+            {this.props.message}
+          </div>
+          <div className="modal-footer">
+            <div className="button-wrapper">
+              <RoundButton color="primary" bind={this.onClickOk.bind(this)}>
+                <div className="button-text">
+                  OK
+              </div>
+              </RoundButton>
+            </div>
+          </div>
+        </ModalWindw>
+      </ModalBg>
+    )
+  }
+}
+
+
+export default AlertModal;

--- a/components/molecules/confirmModal/confirmModal.scss
+++ b/components/molecules/confirmModal/confirmModal.scss
@@ -1,0 +1,20 @@
+@import "../../../public/static/css/global";
+
+.modal-body {
+  white-space: pre-wrap;
+}
+
+.modal-footer {
+  margin-top: 15px;
+
+  display: flex;
+  justify-content: space-around;
+
+  .button-wrapper {
+    width: 40%;
+  }
+
+  .button-text {
+    font-size: 16px;
+  }
+}

--- a/components/molecules/confirmModal/index.tsx
+++ b/components/molecules/confirmModal/index.tsx
@@ -1,0 +1,74 @@
+// 選択肢がOKしか無いアラートのモーダル
+
+import React from 'react';
+import ModalBg from '../../atomos/modalBg';
+import ModalWindw from '../../atomos/modalWindow';
+import RoundButton from '../../atomos/roundButton';
+
+import "./confirmModal.scss";
+
+type Props = {
+  message: string;
+  resolve: (res: Boolean) => void;
+  cleanup: () => void;
+};
+
+type State = {
+  show: boolean;
+};
+
+class ConfirmModal extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: true
+    };
+  }
+
+  onClickCancel() {
+    const { resolve, cleanup } = this.props;
+    this.setState({ show: false }, () => {
+      resolve(false);
+      cleanup();
+    });
+  };
+
+  onClickOk() {
+    const { resolve, cleanup } = this.props;
+    this.setState({ show: false }, () => {
+      resolve(true);
+      cleanup();
+    });
+  };
+
+  render() {
+    return (
+      <ModalBg>
+        <ModalWindw>
+          <div className="modal-body">
+            {this.props.message}
+          </div>
+          <div className="modal-footer">
+            <div className="button-wrapper">
+              <RoundButton color="accent" bind={this.onClickCancel.bind(this)}>
+                <div className="button-text">
+                  キャンセル
+              </div>
+              </RoundButton>
+            </div>
+            <div className="button-wrapper">
+              <RoundButton color="primary" bind={this.onClickOk.bind(this)}>
+                <div className="button-text">
+                  OK
+              </div>
+              </RoundButton>
+            </div>
+          </div>
+        </ModalWindw>
+      </ModalBg>
+    )
+  }
+}
+
+
+export default ConfirmModal;

--- a/components/organisms/boarForm/index.jsx
+++ b/components/organisms/boarForm/index.jsx
@@ -6,6 +6,7 @@ import InfoInput from "../../molecules/infoInput";
 import "../../../utils/validateData";
 import "../../../utils/dict";
 import { getUserData, hasWritePermission } from "../../../utils/gis";
+import { alert } from "../../../utils/modals";
 
 const TRAP = 1;
 const ENV = 2;
@@ -46,10 +47,10 @@ class BoarForm extends React.Component {
     this.validateCatchNum.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     // T, U, S, K, R以外は登録不可
     if (!hasWritePermission("boar")) {
-      alert("Permission Denied: この情報にはアクセスできません");
+      await alert("Permission Denied: この情報にはアクセスできません");
       Router.push("/map");
       return;
     }

--- a/components/organisms/header/index.jsx
+++ b/components/organisms/header/index.jsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import SessionManager from "../../../utils/session";
 import { hasListPermission } from "../../../utils/gis";
 import { getFormUrl } from "../../../utils/questionnaire";
+import { confirm } from "../../../utils/modals";
 
 class Header extends React.Component {
   constructor(props) {
@@ -29,8 +30,8 @@ class Header extends React.Component {
     this.setState({ clicked: !c });
   }
 
-  onLogout() {
-    const result = window.confirm("本当にログアウトしてよろしいですか？");
+  async onLogout() {
+    const result = await confirm("本当にログアウトしてよろしいですか？");
     if (result) {
       SessionManager.logout(document);
     }

--- a/components/organisms/loginForm/index.jsx
+++ b/components/organisms/loginForm/index.jsx
@@ -7,6 +7,7 @@ import "../../../utils/statics";
 import React from "react";
 import { getVersionInfomation } from "../../../utils/versioninfo";
 import { SERVER_URI } from "../../../utils/gis";
+import { confirm } from "../../../utils/modals";
 
 class LoginForm extends React.Component {
   constructor(props) {
@@ -36,7 +37,9 @@ class LoginForm extends React.Component {
     ) {
       // TODO: #173が終わったらそれに置き換える
       if (
-        confirm("このサイトは開発版です。\n安定動作版のサイトへ移動しますか？")
+        await confirm(
+          "このサイトは開発版です。\n安定動作版のサイトへ移動しますか？"
+        )
       ) {
         location.href = "https://boar-map.gifugis.jp/";
       }

--- a/components/organisms/mapBase/index.jsx
+++ b/components/organisms/mapBase/index.jsx
@@ -15,6 +15,7 @@ import {
   hasReadPermission,
   SERVER_URI
 } from "../../../utils/gis";
+import { alert } from "../../../utils/modals";
 
 class MapBase extends React.Component {
   boarIcon = L.icon({

--- a/components/organisms/searchForm/index.jsx
+++ b/components/organisms/searchForm/index.jsx
@@ -7,6 +7,8 @@ import TextInput from "../../atomos/textInput";
 import DateInput from "../../atomos/dateInput";
 import SelectInput from "../../atomos/selectInput";
 
+import { alert } from "../../../utils/modals";
+
 class SearchForm extends React.Component {
   constructor(props) {
     super(props);

--- a/components/organisms/trapForm/index.jsx
+++ b/components/organisms/trapForm/index.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import InfoInput from "../../molecules/infoInput";
 import "../../../utils/validateData";
 import { getUserData, hasWritePermission } from "../../../utils/gis";
+import { alert } from "../../../utils/modals";
 
 class TrapForm extends React.Component {
   constructor(props) {
@@ -29,9 +30,9 @@ class TrapForm extends React.Component {
     this.validateDetail.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (!hasWritePermission("trap")) {
-      alert("Permission Denied: この情報にはアクセスできません");
+      await alert("Permission Denied: この情報にはアクセスできません");
       Router.push("/map");
       return;
     }

--- a/components/organisms/vaccineForm/index.jsx
+++ b/components/organisms/vaccineForm/index.jsx
@@ -4,6 +4,7 @@ import Router from "next/router";
 import React from "react";
 import InfoInput from "../../molecules/infoInput";
 import { getUserData, hasWritePermission } from "../../../utils/gis";
+import { alert } from "../../../utils/modals";
 
 class VaccineForm extends React.Component {
   constructor(props) {
@@ -37,9 +38,9 @@ class VaccineForm extends React.Component {
     this.validateDetail.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (!hasWritePermission("vaccine")) {
-      alert("Permission Denied: この情報にはアクセスできません");
+      await alert("Permission Denied: この情報にはアクセスできません");
       Router.push("/map");
       return;
     }

--- a/components/templates/AddInfo/index.jsx
+++ b/components/templates/AddInfo/index.jsx
@@ -10,6 +10,8 @@ import TrapForm from "../../organisms/trapForm";
 import VaccineForm from "../../organisms/vaccineForm";
 import Router from "next/router";
 
+import { alert } from "../../../utils/modals";
+
 class AddInfo extends React.Component {
   constructor(props) {
     super(props);
@@ -28,7 +30,7 @@ class AddInfo extends React.Component {
     this.state.objectURLs = objectURLs;
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (
       Router.query.lat != undefined ||
       Router.query.lng != undefined ||
@@ -40,7 +42,7 @@ class AddInfo extends React.Component {
         type: Router.query.type
       });
     } else {
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
     }
     // console.log(Router.query.detail);
@@ -105,7 +107,7 @@ class AddInfo extends React.Component {
         this.setState({ isProcessing: false });
       }
     } else {
-      window.alert("入力内容にエラーがあります。ご確認ください。");
+      await alert("入力内容にエラーがあります。ご確認ください。");
       this.setState({ isProcessing: false });
     }
   }

--- a/components/templates/AddLocation/index.jsx
+++ b/components/templates/AddLocation/index.jsx
@@ -8,6 +8,8 @@ import Footer from "../../organisms/footer";
 import Router from "next/router";
 import RoundButton from "../../atomos/roundButton";
 
+import { alert } from "../../../utils/modals";
+
 const DynamicMapComponentWithNoSSR = dynamic(
   () => import("../../organisms/mapForAddInfo"),
   {
@@ -45,7 +47,7 @@ class AddLocation extends React.Component {
     this.saveCenter.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (Router.query.lat != null || Router.query.lng != null) {
       this.state.lat = Router.query.lat;
       this.state.lng = Router.query.lng;
@@ -64,7 +66,7 @@ class AddLocation extends React.Component {
         type: Router.query.type
       });
     } else {
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/add/select");
     }
   }

--- a/components/templates/ConfirmEditedInfo/index.jsx
+++ b/components/templates/ConfirmEditedInfo/index.jsx
@@ -14,7 +14,7 @@ import RoundButton from "../../atomos/roundButton";
 import FooterAdjustment from "../../organisms/footerAdjustment";
 import { getLayerId, hasWritePermission, SERVER_URI } from "../../../utils/gis";
 
-import { alert } from "../../../utils/modals";
+import { alert, confirm } from "../../../utils/modals";
 
 import "whatwg-fetch";
 
@@ -260,7 +260,7 @@ class ConfirmEditedInfo extends React.Component {
   }
 
   async onClickNext() {
-    const result = window.confirm("この内容でよろしいですか？");
+    const result = await confirm("この内容でよろしいですか？");
     if (result) {
       await this.submitInfo();
     }

--- a/components/templates/ConfirmEditedInfo/index.jsx
+++ b/components/templates/ConfirmEditedInfo/index.jsx
@@ -14,6 +14,8 @@ import RoundButton from "../../atomos/roundButton";
 import FooterAdjustment from "../../organisms/footerAdjustment";
 import { getLayerId, hasWritePermission, SERVER_URI } from "../../../utils/gis";
 
+import { alert } from "../../../utils/modals";
+
 import "whatwg-fetch";
 
 class ConfirmEditedInfo extends React.Component {
@@ -39,7 +41,7 @@ class ConfirmEditedInfo extends React.Component {
         deletedIDs: JSON.parse(Router.query.deletedIDs)
       });
     } else {
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
     }
 
@@ -73,12 +75,12 @@ class ConfirmEditedInfo extends React.Component {
       this.state.type != "vaccine"
     ) {
       // このif文は型定義がちゃんとしたら不要
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
       return;
     }
     if (!hasWritePermission(this.state.type)) {
-      alert("Permission Denied: この情報にはアクセスできません");
+      await alert("Permission Denied: この情報にはアクセスできません");
       Router.push("/map");
       return;
     }
@@ -99,11 +101,11 @@ class ConfirmEditedInfo extends React.Component {
       this.state.imageURLs.forEach(url => URL.revokeObjectURL(url));
 
       // mapに飛ばす
-      alert("登録が完了しました。\nご協力ありがとうございました。");
+      await alert("登録が完了しました。\nご協力ありがとうございました。");
       Router.push("/map");
     } catch (e) {
       console.error("アップロードエラー", e);
-      alert(`登録に失敗しました。\n${e}`);
+      await alert(`登録に失敗しました。\n${e}`);
       this.setState({ isProcessing: false });
     }
   }

--- a/components/templates/ConfirmInfo/index.jsx
+++ b/components/templates/ConfirmInfo/index.jsx
@@ -14,6 +14,8 @@ import RoundButton from "../../atomos/roundButton";
 import FooterAdjustment from "../../organisms/footerAdjustment";
 import { getLayerId, hasWritePermission, SERVER_URI } from "../../../utils/gis";
 
+import { alert } from "../../../utils/modals";
+
 import "whatwg-fetch";
 
 class ConfirmInfo extends React.Component {
@@ -45,7 +47,7 @@ class ConfirmInfo extends React.Component {
         detail: JSON.parse(Router.query.detail)
       });
     } else {
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
     }
 
@@ -79,12 +81,12 @@ class ConfirmInfo extends React.Component {
       this.state.type != "vaccine"
     ) {
       // このif文は型定義がちゃんとしたら不要
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
       return;
     }
     if (!hasWritePermission(this.state.type)) {
-      alert("Permission Denied: この情報にはアクセスできません");
+      await alert("Permission Denied: この情報にはアクセスできません");
       Router.push("/map");
       return;
     }
@@ -102,11 +104,11 @@ class ConfirmInfo extends React.Component {
       this.state.imageURLs.forEach(url => URL.revokeObjectURL(url));
 
       // mapに飛ばす
-      alert("登録が完了しました。\nご協力ありがとうございました。");
+      await alert("登録が完了しました。\nご協力ありがとうございました。");
       Router.push("/map");
     } catch (e) {
       console.error("アップロードエラー", e);
-      alert(`登録に失敗しました。\n${e}`);
+      await alert(`登録に失敗しました。\n${e}`);
       this.setState({ isProcessing: false });
     }
   }

--- a/components/templates/ConfirmInfo/index.jsx
+++ b/components/templates/ConfirmInfo/index.jsx
@@ -14,7 +14,7 @@ import RoundButton from "../../atomos/roundButton";
 import FooterAdjustment from "../../organisms/footerAdjustment";
 import { getLayerId, hasWritePermission, SERVER_URI } from "../../../utils/gis";
 
-import { alert } from "../../../utils/modals";
+import { alert, confirm } from "../../../utils/modals";
 
 import "whatwg-fetch";
 
@@ -222,7 +222,7 @@ class ConfirmInfo extends React.Component {
   }
 
   async onClickNext() {
-    const result = window.confirm("この内容でよろしいですか？");
+    const result = await confirm("この内容でよろしいですか？");
     if (result) {
       await this.submitInfo();
     }

--- a/components/templates/Detail/index.jsx
+++ b/components/templates/Detail/index.jsx
@@ -17,6 +17,8 @@ import {
   SERVER_URI
 } from "../../../utils/gis";
 
+import { alert } from "../../../utils/modals";
+
 class Detail extends React.Component {
   state = {
     detail: undefined,
@@ -34,7 +36,7 @@ class Detail extends React.Component {
     // W,K以外でワクチン情報を表示しようとするのは禁止
     if (!hasReadPermission("vaccine")) {
       if (Router.query.type === "vaccine") {
-        console.log("Permission Denied: ワクチン情報にはアクセスできません");
+        await alert("Permission Denied: ワクチン情報にはアクセスできません");
         return;
       }
     }
@@ -69,7 +71,7 @@ class Detail extends React.Component {
       });
     } catch (error) {
       console.log(error);
-      alert("情報の取得に失敗しました。");
+      await alert("情報の取得に失敗しました。");
     }
   }
 
@@ -77,7 +79,7 @@ class Detail extends React.Component {
     this.getFeatureDetail();
   }
 
-  onClickNext() {
+  async onClickNext() {
     if (Object.keys(this.state.detail).length != 0) {
       console.log(JSON.stringify(this.state.detail));
       const type = Router.query.type;
@@ -95,7 +97,7 @@ class Detail extends React.Component {
         url
       );
     } else {
-      alert("情報取得中です");
+      await alert("情報取得中です");
     }
   }
 
@@ -166,14 +168,14 @@ class Detail extends React.Component {
         if (res.status === 200) {
           const json = await res.json();
           console.log(json["status"]);
-          alert("削除しました。");
+          await alert("削除しました。");
           Router.push("/map");
         } else {
           const json = await res.json();
-          alert(json["reason"]);
+          await alert(json["reason"]);
         }
       } catch (error) {
-        alert(error);
+        await alert(error);
       }
     }
   }

--- a/components/templates/Detail/index.jsx
+++ b/components/templates/Detail/index.jsx
@@ -17,7 +17,7 @@ import {
   SERVER_URI
 } from "../../../utils/gis";
 
-import { alert } from "../../../utils/modals";
+import { alert, confirm } from "../../../utils/modals";
 
 class Detail extends React.Component {
   state = {
@@ -106,7 +106,7 @@ class Detail extends React.Component {
   }
 
   async onClickDelete() {
-    const res = confirm("この情報を削除します。\n本当によろしいですか？");
+    const res = await confirm("この情報を削除します。\n本当によろしいですか？");
     if (res) {
       // id取得
       const id = this.state.detail["properties"]["ID$"];

--- a/components/templates/EditInfo/index.jsx
+++ b/components/templates/EditInfo/index.jsx
@@ -10,6 +10,8 @@ import TrapForm from "../../organisms/trapForm";
 import VaccineForm from "../../organisms/vaccineForm";
 import Router from "next/router";
 
+import { alert } from "../../../utils/modals";
+
 // import ImageInput from "../../organisms/imageInput";
 
 class EditInfo extends React.Component {
@@ -39,7 +41,7 @@ class EditInfo extends React.Component {
     this.state.deletedIDs.push(deletedID);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (Router.query.type != undefined || Router.query.detail != undefined) {
       const detail = JSON.parse(Router.query.detail);
       this.setState({
@@ -51,7 +53,7 @@ class EditInfo extends React.Component {
         imageIDs: JSON.parse(Router.query.imageIDs)
       });
     } else {
-      alert("情報の取得に失敗しました。\nもう一度やり直してください。");
+      await alert("情報の取得に失敗しました。\nもう一度やり直してください。");
       Router.push("/map");
     }
     // console.log(Router.query.detail);
@@ -115,7 +117,7 @@ class EditInfo extends React.Component {
         this.setState({ isProcessing: false });
       }
     } else {
-      window.alert("入力内容にエラーがあります。ご確認ください。");
+      await alert("入力内容にエラーがあります。ご確認ください。");
       this.setState({ isProcessing: false });
     }
   }

--- a/components/templates/List/index.jsx
+++ b/components/templates/List/index.jsx
@@ -8,6 +8,8 @@ import ListTable from "../../organisms/listTable";
 import "../../../utils/statics";
 import { hasListPermission, SERVER_URI } from "../../../utils/gis";
 
+import { alert } from "../../../utils/modals";
+
 class List extends React.Component {
   constructor(props) {
     super(props);
@@ -37,7 +39,7 @@ class List extends React.Component {
       const features = await this.getFeatures(data);
       console.log(features);
       if (features.length === 0) {
-        alert("データが1件も見つかりませんでした。");
+        await alert("データが1件も見つかりませんでした。");
         this.setState({
           searched: false,
           searching: false
@@ -53,7 +55,7 @@ class List extends React.Component {
         searching: false
       });
     } catch (error) {
-      alert(`エラーが発生しました．\n${error}`);
+      await alert(`エラーが発生しました．\n${error}`);
       this.setState({ searching: false });
     }
   }
@@ -167,11 +169,11 @@ class List extends React.Component {
         this.setState({ downloading: false });
       } else {
         const json = await res.json();
-        alert(json["reason"]);
+        await alert(json["reason"]);
         this.setState({ downloading: false });
       }
     } catch (error) {
-      alert(error);
+      await alert(error);
       this.setState({ downloading: false });
     }
   }

--- a/components/templates/SelectType/index.jsx
+++ b/components/templates/SelectType/index.jsx
@@ -8,6 +8,7 @@ import Footer from "../../organisms/footer";
 import RoundButton from "../../atomos/roundButton";
 import FooterAdjustment from "../../organisms/footerAdjustment";
 
+import { alert } from "../../../utils/modals";
 class SelectType extends React.Component {
   constructor(props) {
     super(props);
@@ -18,13 +19,13 @@ class SelectType extends React.Component {
     Router.push("/map");
   }
 
-  onClickNext() {
+  async onClickNext() {
     // なんでこれで動くのか，JavaScriptの知識が足りないためわからない・・・
     const selector = new InfoTypeSelector();
     const selectedItem = selector.getSelectedItem();
     console.log("parent", selectedItem);
     if (selectedItem == null) {
-      window.alert("登録する情報の種類が選択されていません!!");
+      await alert("登録する情報の種類が選択されていません!!");
       return;
     }
     // チェックが有る場合
@@ -35,7 +36,7 @@ class SelectType extends React.Component {
       case "trap":
         break;
       default:
-        window.alert("登録する情報の種類が選択されていません!!");
+        await alert("登録する情報の種類が選択されていません!!");
         return;
     }
     Router.push({ pathname: url, query: { type: selectedItem } }, url);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "^14.14.20",
     "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.2",
     "@zeit/next-sass": "^1.0.1",
     "autoprefixer": "^9.7.3",
     "babel-eslint": "^10.0.3",

--- a/utils/modals.tsx
+++ b/utils/modals.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom';
 import AlertModal from '../components/molecules/alertModal';
+import ConfirmModal from '../components/molecules/confirmModal';
 
 
 export const alert = (message: string) => {
@@ -16,6 +17,35 @@ export const alert = (message: string) => {
     try {
       ReactDOM.render(
         <AlertModal
+          message={message}
+          resolve={resolve}
+          cleanup={cleanup} />,
+        wrapper
+      );
+    } catch (e) {
+      cleanup();
+      reject(e);
+      throw e;
+    }
+  });
+  return promise;
+}
+
+
+export const confirm = (message: string) => {
+  // nextのアプリケーションが描画される要素を取得
+  const nextDiv = document.getElementById("__next");
+  // モーダルを表示するdivを作成
+  const wrapper = nextDiv.appendChild(document.createElement("div"));
+  // モーダルを消去する関数
+  const cleanup = () => {
+    ReactDOM.unmountComponentAtNode(wrapper);
+    return setTimeout(() => wrapper.remove());
+  };
+  const promise = new Promise<Boolean>((resolve, reject) => {
+    try {
+      ReactDOM.render(
+        <ConfirmModal
           message={message}
           resolve={resolve}
           cleanup={cleanup} />,

--- a/utils/modals.tsx
+++ b/utils/modals.tsx
@@ -16,7 +16,11 @@ export const confirm = async (message: string) => {
 const showModal = (type: "confirm" | "alert", message: string) => {
   // nextのアプリケーションが描画される要素を取得
   const nextDiv = document.getElementById("__next");
-  // スクロール禁止（結構無理やり止めてる）
+  // スクロールのきっかけになるイベントを停止
+  const handleScrollEvent = (e: TouchEvent | WheelEvent) => e.preventDefault();
+  nextDiv.addEventListener('wheel', handleScrollEvent, { passive: false });
+  nextDiv.addEventListener('touchmove', handleScrollEvent, { passive: false });
+  // 上記以外の方法でもスクロール禁止（結構無理やり止めてる）
   const x = window.pageXOffset;
   const y = window.pageYOffset;
   const handleScroll = () => window.scrollTo(x, y);
@@ -25,12 +29,13 @@ const showModal = (type: "confirm" | "alert", message: string) => {
   const wrapper = nextDiv.appendChild(document.createElement("div"));
   wrapper.style.width = '100vw';
   wrapper.style.height = '100vh';
-  wrapper.style.position = 'absolute';
-  wrapper.style.top = y + 'px';
-  wrapper.style.left = x + 'px';
+  wrapper.style.position = 'fixed';
+  wrapper.style.zIndex = '100';
   // モーダルを消去する関数
   const cleanup = () => {
     ReactDOM.unmountComponentAtNode(wrapper);
+    nextDiv.removeEventListener('wheel', handleScrollEvent);
+    nextDiv.removeEventListener('touchmove', handleScrollEvent);
     window.removeEventListener('scroll', handleScroll);
     return setTimeout(() => wrapper.remove());
   };

--- a/utils/modals.tsx
+++ b/utils/modals.tsx
@@ -1,0 +1,31 @@
+import ReactDOM from 'react-dom';
+import AlertModal from '../components/molecules/alertModal';
+
+
+export const alert = (message: string) => {
+  // nextのアプリケーションが描画される要素を取得
+  const nextDiv = document.getElementById("__next");
+  // モーダルを表示するdivを作成
+  const wrapper = nextDiv.appendChild(document.createElement("div"));
+  // モーダルを消去する関数
+  const cleanup = () => {
+    ReactDOM.unmountComponentAtNode(wrapper);
+    return setTimeout(() => wrapper.remove());
+  };
+  const promise = new Promise<Boolean>((resolve, reject) => {
+    try {
+      ReactDOM.render(
+        <AlertModal
+          message={message}
+          resolve={resolve}
+          cleanup={cleanup} />,
+        wrapper
+      );
+    } catch (e) {
+      cleanup();
+      reject(e);
+      throw e;
+    }
+  });
+  return promise;
+}

--- a/utils/modals.tsx
+++ b/utils/modals.tsx
@@ -3,23 +3,51 @@ import AlertModal from '../components/molecules/alertModal';
 import ConfirmModal from '../components/molecules/confirmModal';
 
 
-export const alert = (message: string) => {
+export const alert = async (message: string) => {
+  return await showModal('alert', message);
+}
+
+
+export const confirm = async (message: string) => {
+  return await showModal('confirm', message);
+}
+
+// confirmとalertはほぼ同じ動作するので動作をまとめる
+const showModal = (type: "confirm" | "alert", message: string) => {
   // nextのアプリケーションが描画される要素を取得
   const nextDiv = document.getElementById("__next");
+  // スクロール禁止（結構無理やり止めてる）
+  const x = window.pageXOffset;
+  const y = window.pageYOffset;
+  const handleScroll = () => window.scrollTo(x, y);
+  window.addEventListener('scroll', handleScroll);
   // モーダルを表示するdivを作成
   const wrapper = nextDiv.appendChild(document.createElement("div"));
+  wrapper.style.width = '100vw';
+  wrapper.style.height = '100vh';
+  wrapper.style.position = 'absolute';
+  wrapper.style.top = y + 'px';
+  wrapper.style.left = x + 'px';
   // モーダルを消去する関数
   const cleanup = () => {
     ReactDOM.unmountComponentAtNode(wrapper);
+    window.removeEventListener('scroll', handleScroll);
     return setTimeout(() => wrapper.remove());
   };
   const promise = new Promise<Boolean>((resolve, reject) => {
     try {
+      const modal =
+        type === 'confirm' ?
+          <ConfirmModal
+            message={message}
+            resolve={resolve}
+            cleanup={cleanup} /> :
+          <AlertModal
+            message={message}
+            resolve={resolve}
+            cleanup={cleanup} />;
       ReactDOM.render(
-        <AlertModal
-          message={message}
-          resolve={resolve}
-          cleanup={cleanup} />,
+        modal,
         wrapper
       );
     } catch (e) {
@@ -29,33 +57,4 @@ export const alert = (message: string) => {
     }
   });
   return promise;
-}
-
-
-export const confirm = (message: string) => {
-  // nextのアプリケーションが描画される要素を取得
-  const nextDiv = document.getElementById("__next");
-  // モーダルを表示するdivを作成
-  const wrapper = nextDiv.appendChild(document.createElement("div"));
-  // モーダルを消去する関数
-  const cleanup = () => {
-    ReactDOM.unmountComponentAtNode(wrapper);
-    return setTimeout(() => wrapper.remove());
-  };
-  const promise = new Promise<Boolean>((resolve, reject) => {
-    try {
-      ReactDOM.render(
-        <ConfirmModal
-          message={message}
-          resolve={resolve}
-          cleanup={cleanup} />,
-        wrapper
-      );
-    } catch (e) {
-      cleanup();
-      reject(e);
-      throw e;
-    }
-  });
-  return promise;
-}
+};

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -48,3 +48,4 @@ export const getBrowser = (): Browser => {
   if (ua.indexOf("safari") !== -1) return "safari";
   return "other";
 }
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,6 +387,22 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@^17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
+  integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
@@ -394,6 +410,11 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"


### PR DESCRIPTION
#173 関連

**めちゃくちゃ間の悪い感じでできてしまったので、Version 1.1.0には含めず，次回バージョンで統合します．**

- utilsにmodals.tsxを追加
- `awati alert(message: string)`, `await confirm(message: string): boolean`で利用可能
- 既存のalertとconfirmは置換済み