### PR TITLE
Improve/update image input type

### DIFF
--- a/src/components/templates/newDataForm/commonInfoInput/index.tsx
+++ b/src/components/templates/newDataForm/commonInfoInput/index.tsx
@@ -60,9 +60,12 @@ const CommonInfoInputTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEdi
     }
 
     setImageArray(
-      (paramParser.currentData.inputData.teethImageUrls ?? []).concat(
-        paramParser.currentData.inputData.otherImageUrls ?? [],
-      ),
+      (paramParser.currentData.inputData.teethImageUrls ?? [])
+      .concat(paramParser.currentData.inputData.otherImageUrls ?? [],)
+      .concat(paramParser.currentData.inputData.captureImageUrls ?? [],)
+      .concat(paramParser.currentData.inputData.captureWithLineImageUrls ?? [],)
+      .concat(paramParser.currentData.inputData.disposeImageUrls ?? [],)
+      .concat(paramParser.currentData.inputData.burialImageUrls ?? [],)
     );
     setServerImages(() => {
       const featureProps = paramParser.currentData.inputData?.gisData?.properties as Record<

--- a/src/components/templates/newDataForm/dataConfirmTemplate/index.tsx
+++ b/src/components/templates/newDataForm/dataConfirmTemplate/index.tsx
@@ -13,8 +13,10 @@ import { getAccessToken } from '@/utils/currentUser';
 import { InputFormData, useFormDataParser } from '@/utils/form-data';
 import { to_header_color, to_header_title } from '@/utils/header';
 import { alert, confirm } from '@/utils/modal';
+import { createImageConfigs } from '@/utils/imageConfig';
 
 import { InputFormTemplateCommonProps } from '../interfaces';
+import { ImagewithLocation } from '@/components/atomos/imageInput/interface';
 
 const DataConfirmTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditing }) => {
   const router = useRouter();
@@ -25,6 +27,13 @@ const DataConfirmTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditing
   const [featureInfo, setFeatureInfo] = useState<FeatureBase | null>(null);
 
   const type = paramParser.currentData.dataType;
+  const type_srv = paramParser.currentData.editData?.type_srv;
+  
+  const imageConfigs = useMemo(
+    () => createImageConfigs({ type, type_srv , isEditing}),
+    [type, type_srv],
+  );
+
   const t = useMemo(() => {
     const tt = paramParser.currentData.editData?.type_srv;
     if (tt == null) {
@@ -130,45 +139,29 @@ const DataConfirmTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditing
       // 画像を削除
       await Promise.all(delImg.map((e) => deleteImage(e)));
 
-      // 対象の場合は歯列写真をアップロードしてFeatureにセット
-      if (
-        (!isEditing && paramParser.currentData.dataType === 'boar') ||
-        (isEditing && paramParser.currentData.editData?.type_srv === 'boar-2')
-      ) {
-        const teethImageIds = (
+      for (const config of Object.values(imageConfigs)) {
+        if (!config.condition) continue;
+        const imageUrls =
+          paramParser.currentData.inputData[config.frontUrlKey] || [];
+
+        // 画像アップロード
+        const uploadedIds = (
           await Promise.all(
-            (paramParser.currentData.inputData.teethImageUrls || []).map((e) =>
-              uploadImage(e.objectURL),
-            ),
+            (imageUrls as ImagewithLocation[]).map((e) => uploadImage(e.objectURL)),
           )
-        ).filter((e) => e != null);
+        ).filter((e): e is string => e != null);
+        
+        const propertyKey = config.propertyKey;
 
-        const currentIds = (newData.inputData.gisData.properties as Record<string, string>)[
-          '歯列写真ID'
-        ].split(',');
-        const newIds = currentIds.concat(teethImageIds as string[]).filter((e) => e);
-        (newData.inputData.gisData.properties as Record<string, string>)['歯列写真ID'] =
-          newIds.join(',');
+        const properties =
+          newData.inputData.gisData.properties as Record<string, string>;
+
+        const currentIds = (properties[propertyKey] || '').split(',');
+        const newIds = currentIds.concat(uploadedIds).filter(Boolean);
+
+        //properties[propertyKey] = newIds.join(',');
+        (newData.inputData.gisData.properties as Record<string, string>)[propertyKey] = newIds.join(',');
       }
-
-      // 画像をアップロードしてFeatureにセット
-      const otherImageIds = (
-        await Promise.all(
-          (paramParser.currentData.inputData.otherImageUrls || []).map((e) =>
-            uploadImage(e.objectURL),
-          ),
-        )
-      ).filter((e) => e != null);
-      const currentIds = (
-        (newData.inputData.gisData.properties as Record<string, string>)[
-          t == 'boar' ? '写真ID' : '画像ID'
-        ] || ''
-      ).split(',');
-      const newIds = currentIds.concat(otherImageIds as string[]).filter((e) => e);
-
-      (newData.inputData.gisData.properties as Record<string, string>)[
-        t == 'boar' ? '写真ID' : '画像ID'
-      ] = newIds.join(',');
 
       let res = null;
       if (isEditing) {
@@ -221,8 +214,13 @@ const DataConfirmTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditing
     setImageArray(
       (paramParser.currentData.inputData.teethImageUrls ?? [])
         .concat(paramParser.currentData.inputData.otherImageUrls ?? [])
+        .concat(paramParser.currentData.inputData.captureImageUrls ?? [],)
+        .concat(paramParser.currentData.inputData.captureWithLineImageUrls ?? [],)
+        .concat(paramParser.currentData.inputData.disposeImageUrls ?? [],)
+        .concat(paramParser.currentData.inputData.burialImageUrls ?? [],)
         .map((e) => e.objectURL),
     );
+
     setServerImages(() => {
       const featureProps = paramParser.currentData.inputData?.gisData?.properties as Record<
         string,

--- a/src/components/templates/newDataForm/imageSelector/index.tsx
+++ b/src/components/templates/newDataForm/imageSelector/index.tsx
@@ -10,16 +10,40 @@ import Header from '@/components/organisms/header';
 import { InputFormData, useFormDataParser } from '@/utils/form-data';
 import { to_header_color } from '@/utils/header';
 import { alert } from '@/utils/modal';
+import { createImageConfigs } from '@/utils/imageConfig';
 
 import { InputFormTemplateCommonProps } from '../interfaces';
+
+type AllImageIdsState = {
+  [configKey: string]: string[];
+};
+
+type AllImagesState = {
+  [configKey: string]: ImagewithLocation[] | null;
+};
 
 const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditing }) => {
   const router = useRouter();
   const paramParser = useFormDataParser();
 
   const type = paramParser.currentData.dataType;
+  const type_srv = paramParser.currentData.editData?.type_srv;
 
-  const currentServerOtherImageIds = useMemo(() => {
+  const imageConfigs = useMemo(
+    () => createImageConfigs({ type, type_srv, isEditing }),
+    [type, type_srv],
+  );
+
+  const getInitialImages = useCallback((configKey: string): ImagewithLocation[] | null => {
+    const config = imageConfigs[configKey];
+    if (!config) return null;
+    
+    const inputData = paramParser.currentData.inputData as Record<string, any>;
+    return inputData?.[config.frontUrlKey] ?? null;
+  }, [imageConfigs, paramParser.currentData.inputData]);
+
+  // 各画像タイプのサーバーIDを取得するヘルパー関数
+  const getServerImageIds = useCallback((configKey: string): string[] => {
     if (!isEditing) return [];
 
     const featureProps = paramParser.currentData.inputData?.gisData?.properties as
@@ -27,40 +51,49 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
       | undefined;
     if (!featureProps) return [];
 
-    const t = paramParser.currentData.editData?.type_srv;
+    const config = imageConfigs[configKey];
+    if (!config || !config.condition) return [];
 
-    return (featureProps[t === 'boar-2' ? '写真ID' : '画像ID'] ?? '').split(',').filter((e) => e);
-  }, [
-    isEditing,
-    paramParser.currentData.inputData?.gisData,
-    paramParser.currentData.editData?.type_srv,
-  ]);
-  const [newOtherImageIds, setNewOtherImageIds] = useState<string[]>(currentServerOtherImageIds);
-  const [otherImages, setOtherImages] = useState<ImagewithLocation[] | null>(
-    paramParser.currentData.inputData?.otherImageUrls ?? null,
-  );
+    const propertyKey = config.propertyKey;
 
-  const currentServerTeethImageIds = useMemo(() => {
-    if (!isEditing) return [];
+    return (featureProps[propertyKey] ?? '').split(',').filter((e) => e);
+  }, [isEditing, paramParser.currentData.inputData?.gisData, imageConfigs, type_srv]);
 
-    const featureProps = paramParser.currentData.inputData?.gisData?.properties as
-      | Record<string, string>
-      | undefined;
-    if (!featureProps) return [];
+  const [newAllImageIds, setNewAllImageIds] = useState<AllImageIdsState>(() => {
+    const initialIds: AllImageIdsState = {};
+    
+    Object.keys(imageConfigs).forEach((key) => {
+      initialIds[key] = getServerImageIds(key);
+    });
+    
+    return initialIds;
+  });
 
-    const t = paramParser.currentData.editData?.type_srv;
-    if (t !== 'boar-2') return [];
+  const [allImages, setAllImages] = useState<AllImagesState>(() => {
+    const initialImages: AllImagesState = {};
+    
+    Object.keys(imageConfigs).forEach((key) => {
+      initialImages[key] = getInitialImages(key);
+    });
+    
+    return initialImages;
+  });
 
-    return featureProps['歯列写真ID'].split(',').filter((e) => e);
-  }, [
-    isEditing,
-    paramParser.currentData.inputData?.gisData,
-    paramParser.currentData.editData?.type_srv,
-  ]);
-  const [newTeethImageIds, setNewTeethImageIds] = useState<string[]>(currentServerTeethImageIds);
-  const [teethImages, setTeethImages] = useState<ImagewithLocation[] | null>(
-    paramParser.currentData.inputData?.teethImageUrls ?? null,
-  );
+  // 特定の画像タイプのIDを更新する関数
+  const updateImageIds = useCallback((configKey: string, ids: string[]) => {
+    setNewAllImageIds((prev) => ({
+      ...prev,
+      [configKey]: ids,
+    }));
+  }, []);
+
+  // 特定の画像タイプの画像を更新する関数
+  const updateImages = useCallback((configKey: string, images: ImagewithLocation[] | null) => {
+    setAllImages((prev) => ({
+      ...prev,
+      [configKey]: images,
+    }));
+  }, []);
 
   useEffect(() => {
     if (!paramParser.currentData.dataType) {
@@ -76,13 +109,9 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
   }, [paramParser.currentData]);
 
   const onClickNext = useCallback(() => {
-    const t = paramParser.currentData.editData?.type_srv;
-
-    // 現在の入力情報を保存する。
     const newData = JSON.parse(JSON.stringify(paramParser.currentData)) as InputFormData;
 
     if (!isEditing && !newData.inputData?.gisData) {
-      // 新規登録の場合はベースとなるデータを作成
       newData.inputData.gisData = {
         geometry: {
           type: 'Point',
@@ -92,27 +121,33 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
         type: 'Feature',
       };
     }
+
     const featureProps = newData.inputData?.gisData?.properties as Record<string, string>;
 
-    newData.inputData.teethImageUrls = teethImages ?? [];
-    newData.inputData.otherImageUrls = otherImages ?? [];
+    // すべての画像設定に対して処理
+    Object.entries(imageConfigs).forEach(([configKey, config]) => {
+      if (!config.condition) return;
 
-    if (type === 'boar') {
-      featureProps['歯列写真ID'] = newTeethImageIds.join(',');
-    }
+      // 画像URLを保存
+      const urlKey = config.frontUrlKey;
+      (newData.inputData as any)[urlKey] = allImages[configKey] ?? [];
 
-    featureProps[t === 'boar-2' ? '写真ID' : '画像ID'] = newOtherImageIds.join(',');
+      // 画像IDをプロパティに保存
+      const propertyKey = config.propertyKey;
+      
+      featureProps[propertyKey] = newAllImageIds[configKey]?.join(',') ?? '';
+    });
+
+    console.log(newData);
 
     paramParser.updateData(newData as InputFormData);
-
-    // ページを遷移する
 
     if (isEditing) {
       router.push('/edit/info');
     } else {
       router.push('/add/location');
     }
-  }, [teethImages, otherImages, newOtherImageIds, newTeethImageIds, paramParser.currentData]);
+  }, [allImages, newAllImageIds, imageConfigs, type_srv, paramParser, isEditing, router]);
 
   const onClickPrev = useCallback(() => {
     if (sessionStorage.getItem('fromList') === "1") {
@@ -143,23 +178,15 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
     }
   }, [paramParser.currentData]);
 
-  const onChangeTeethImages = (files: ImagewithLocation[]) => {
-    if (files.length === 0) {
-      setTeethImages(null);
-    } else {
-      setTeethImages(files);
-    }
-  };
-
-  const onChangeOtherImages = (files: ImagewithLocation[]) => {
-    if (files.length === 0) {
-      setOtherImages(null);
-    } else {
-      setOtherImages(files);
-    }
-  };
+  const createImageChangeHandler = useCallback((configKey: string) => {
+    return (files: ImagewithLocation[]) => {
+      updateImages(configKey, files.length === 0 ? null : files);
+    };
+  }, [updateImages]);
 
   if (paramParser.isLoading) return <></>;
+
+  const activeConfigs = Object.entries(imageConfigs).filter(([_, config]) => config.condition);
 
   return (
     <div>
@@ -173,11 +200,7 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
             <>
               <div className='mt-2 flex'>
                 <div>※&nbsp;</div>
-                <div>歯列の写真は2枚まで登録できます。</div>
-              </div>
-              <div className='mt-2 flex'>
-                <div>※&nbsp;</div>
-                <div>その他の写真は8枚まで登録できます。</div>
+                <div>各項目２枚まで登録可能です。</div>
               </div>
               <div className='mt-2 flex'>
                 <div>※&nbsp;</div>
@@ -190,14 +213,6 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
               <div className='mt-3 flex'>
                 <div>※&nbsp;</div>
                 <div>
-                  <span className='font-bold'>有害捕獲の場合:</span>
-                  <br />
-                  ・検体採取個体の歯列写真
-                </div>
-              </div>
-              <div className='flex'>
-                <div>※&nbsp;</div>
-                <div>
                   <span className='font-bold'>調査捕獲の場合:</span>
                   <br />
                   ・検体採取個体の歯列写真
@@ -205,43 +220,45 @@ const ImageSelectorTemplate: React.FC<InputFormTemplateCommonProps> = ({ isEditi
                   ・全捕獲個体のそれぞれ全体の写真
                 </div>
               </div>
+              <div className='flex'>
+                <div>※&nbsp;</div>
+                <div>
+                  <span className='font-bold'>狩猟の場合:</span>
+                  <br />
+                  ・検体採取個体の歯列写真
+                  <br />
+                  ・捕獲個体の写真
+                </div>
+              </div>
+              <div className='flex'>
+                <div>※&nbsp;</div>
+                <div>
+                  <span className='font-bold'>有害捕獲の場合:</span>
+                  <br />
+                  ・検体採取個体の歯列写真
+                </div>
+              </div>
             </>
           ) : (
             <>※ 画像は10枚まで登録できます。</>
           )}
         </div>
-        {type != 'boar' ? (
-          <></>
-        ) : (
-          <div className='box-border w-full px-[15px] py-2'>
+          {activeConfigs.map(([configKey, config]) => (
+          <div key={configKey} className='box-border w-full px-[15px] py-2'>
             <div className='text-justify text-lg font-bold text-text'>
-              歯列の画像
+              {config.label}
               <ImageInput
-                max_count={type === 'boar' ? 2 : 10}
+                max_count={config.max}
                 type={type}
                 single_file={false}
-                onChange={onChangeTeethImages}
-                objectURLs={teethImages == null ? undefined : teethImages}
-                imageIDs={isEditing ? currentServerTeethImageIds : undefined}
-                onServerImageDeleted={(list) => setNewTeethImageIds(list)}
+                onChange={createImageChangeHandler(configKey)}
+                objectURLs={allImages[configKey] ?? undefined}
+                imageIDs={isEditing ? getServerImageIds(configKey) : undefined}
+                onServerImageDeleted={(list) => updateImageIds(configKey, list)}
               />
             </div>
           </div>
-        )}
-        <div className='box-border w-full px-[15px] py-2'>
-          <div className='text-justify text-lg font-bold text-text'>
-            {type == 'boar' ? 'その他の' : ''}画像
-            <ImageInput
-              max_count={type === 'boar' ? 8 : 10}
-              type={type}
-              single_file={false}
-              onChange={onChangeOtherImages}
-              objectURLs={otherImages == null ? undefined : otherImages}
-              imageIDs={isEditing ? currentServerOtherImageIds : undefined}
-              onServerImageDeleted={(list) => setNewOtherImageIds(list)}
-            />
-          </div>
-        </div>
+        ))}
       </div>
       <FooterAdjustment />
       <div className='fixed bottom-0 w-full'>

--- a/src/utils/form-data.ts
+++ b/src/utils/form-data.ts
@@ -13,6 +13,10 @@ export interface InputFormData {
   inputData: {
     otherImageUrls?: ImagewithLocation[];
     teethImageUrls?: ImagewithLocation[];
+    captureImageUrls?: ImagewithLocation[];
+    captureWithLineImageUrls?: ImagewithLocation[];
+    disposeImageUrls?: ImagewithLocation[];
+    burialImageUrls?: ImagewithLocation[];
     newImageIds?: string[];
     gisData?: FeatureBase;
   };

--- a/src/utils/imageConfig.ts
+++ b/src/utils/imageConfig.ts
@@ -1,0 +1,91 @@
+
+import { InputFormData } from '@/utils/form-data';
+
+type ImageConfig = {
+  label: string;
+  propertyKey: string;
+  frontPropertyKey: string;
+  urlKey: keyof InputFormData["inputData"];
+  frontUrlKey: keyof InputFormData["inputData"];
+  max: number;
+  condition: boolean;
+};
+
+type ImageConfigsType = {
+  [key: string]: ImageConfig;
+};
+
+export const createImageConfigs = (ctx: {
+  type?: string;
+  type_srv?: string | null;
+  isEditing: boolean;
+}): ImageConfigsType => {
+  const isBoar = Boolean (!ctx.isEditing && ctx.type === 'boar');
+  const isEditBoar = Boolean (ctx.isEditing && ctx.type_srv === 'boar-2');
+
+  return {
+    teeth: {
+      label: '歯列写真(遠沈管の番号と下アゴの奥歯の本数がわかるように撮影)',
+      propertyKey: '歯列写真ID',
+      frontPropertyKey: '歯列写真ID',
+      urlKey: 'teethImageUrls',
+      frontUrlKey: 'teethImageUrls',
+      max: 2,
+      condition: isBoar || isEditBoar,
+    },
+    captureRecord: {
+      label: '捕獲個体（右向、日付入り）と捕獲者（又は看板）',
+      propertyKey: '写真ID',
+      frontPropertyKey: '捕獲写真ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'captureImageUrls',
+      max: 2,
+      condition: isBoar,
+    },
+    captureRecordWithLine: {
+      label: '捕獲個体（右向、日付入り）と捕獲者（又は看板）、捕獲個体の日付の上に線を引いたもの',
+      propertyKey: '写真ID',
+      frontPropertyKey: '線入り捕獲写真ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'captureWithLineImageUrls',
+      max: 2,
+      condition: isBoar,
+    },
+    disposal: {
+      label: '処分方法がわかる写真等',
+      propertyKey: '写真ID',
+      frontPropertyKey: '処分写真ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'disposeImageUrls',
+      max: 2,
+      condition: isBoar,
+    },
+    burial: {
+      label: '埋却処分の完了写真（埋却処分の場合のみ）',
+      propertyKey: '写真ID',
+      frontPropertyKey: '埋葬写真ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'burialImageUrls',
+      max: 2,
+      condition: isBoar,
+    },
+    other: {
+      label: '画像',
+      propertyKey: '画像ID',
+      frontPropertyKey: '画像ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'otherImageUrls',
+      max: 10,
+      condition: !isBoar && !isEditBoar,
+    },
+    boarOther: {
+      label: 'その他の画像',
+      propertyKey: '写真ID',
+      frontPropertyKey: '画像ID',
+      urlKey: 'otherImageUrls',
+      frontUrlKey: 'otherImageUrls',
+      max: 10,
+      condition: isEditBoar
+    }
+  };
+};

--- a/src/utils/imageConfig.ts
+++ b/src/utils/imageConfig.ts
@@ -4,7 +4,6 @@ import { InputFormData } from '@/utils/form-data';
 type ImageConfig = {
   label: string;
   propertyKey: string;
-  frontPropertyKey: string;
   urlKey: keyof InputFormData["inputData"];
   frontUrlKey: keyof InputFormData["inputData"];
   max: number;
@@ -27,7 +26,6 @@ export const createImageConfigs = (ctx: {
     teeth: {
       label: '歯列写真(遠沈管の番号と下アゴの奥歯の本数がわかるように撮影)',
       propertyKey: '歯列写真ID',
-      frontPropertyKey: '歯列写真ID',
       urlKey: 'teethImageUrls',
       frontUrlKey: 'teethImageUrls',
       max: 2,
@@ -36,7 +34,6 @@ export const createImageConfigs = (ctx: {
     captureRecord: {
       label: '捕獲個体（右向、日付入り）と捕獲者（又は看板）',
       propertyKey: '写真ID',
-      frontPropertyKey: '捕獲写真ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'captureImageUrls',
       max: 2,
@@ -45,7 +42,6 @@ export const createImageConfigs = (ctx: {
     captureRecordWithLine: {
       label: '捕獲個体（右向、日付入り）と捕獲者（又は看板）、捕獲個体の日付の上に線を引いたもの',
       propertyKey: '写真ID',
-      frontPropertyKey: '線入り捕獲写真ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'captureWithLineImageUrls',
       max: 2,
@@ -54,7 +50,6 @@ export const createImageConfigs = (ctx: {
     disposal: {
       label: '処分方法がわかる写真等',
       propertyKey: '写真ID',
-      frontPropertyKey: '処分写真ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'disposeImageUrls',
       max: 2,
@@ -63,7 +58,6 @@ export const createImageConfigs = (ctx: {
     burial: {
       label: '埋却処分の完了写真（埋却処分の場合のみ）',
       propertyKey: '写真ID',
-      frontPropertyKey: '埋葬写真ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'burialImageUrls',
       max: 2,
@@ -72,7 +66,6 @@ export const createImageConfigs = (ctx: {
     other: {
       label: '画像',
       propertyKey: '画像ID',
-      frontPropertyKey: '画像ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'otherImageUrls',
       max: 10,
@@ -81,10 +74,9 @@ export const createImageConfigs = (ctx: {
     boarOther: {
       label: 'その他の画像',
       propertyKey: '写真ID',
-      frontPropertyKey: '画像ID',
       urlKey: 'otherImageUrls',
       frontUrlKey: 'otherImageUrls',
-      max: 10,
+      max: 8,
       condition: isEditBoar
     }
   };


### PR DESCRIPTION
新規情報登録フォームで、画像登録を順番に登録できるように変更。
サーバー側の変更をすると様々な部分に影響が出そうだったので、表示だけが変わっています。

歯列写真以外はサーバーに送信するとき、その他の写真として扱われています。